### PR TITLE
Fix undefined json in Jinja template

### DIFF
--- a/app.py
+++ b/app.py
@@ -118,7 +118,7 @@ def config():
     c.execute('SELECT * FROM students')
     students = c.fetchall()
     conn.close()
-    return render_template('config.html', config=cfg, teachers=teachers, students=students)
+    return render_template('config.html', config=cfg, teachers=teachers, students=students, json=json)
 
 
 def generate_schedule():


### PR DESCRIPTION
## Summary
- ensure `json` is available in `config.html` by passing the module in

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6878b73fb70c8322bc08602422315909