### PR TITLE
Support multiple subjects per teacher

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -21,7 +21,7 @@
             {% for t in teachers %}
             <input type="hidden" name="teacher_id" value="{{ t['id'] }}">
             <label>Name: <input type="text" name="teacher_name" value="{{ t['name'] }}"></label>
-            <label>Subject: <input type="text" name="teacher_subject" value="{{ t['subject'] }}"></label><br>
+            <label>Subjects: <input type="text" name="teacher_subjects" value="{{ ', '.join(json.loads(t['subjects'])) }}"></label><br>
             {% endfor %}
         </fieldset>
         <fieldset>

--- a/templates/timetable.html
+++ b/templates/timetable.html
@@ -11,7 +11,7 @@
         <tr>
             <th>Slot</th>
             {% for t in teachers %}
-            <th>{{ t['name'] }}<br>{{ t['subject'] }}</th>
+            <th>{{ t['name'] }}<br>{{ ', '.join(json.loads(t['subjects'])) }}</th>
             {% endfor %}
         </tr>
         {% for slot in slots %}


### PR DESCRIPTION
## Summary
- allow teachers to store a JSON list of subjects
- show comma-separated teacher subjects in config page
- generate schedules accounting for each teacher's subjects

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails if Flask missing)*
- `pip install flask`
- `python app.py`

------
https://chatgpt.com/codex/tasks/task_e_6878de0b8fb08322ad679252fb8cba7e