### PR TITLE
Integrate CP‑SAT model

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,27 @@ python app.py
 ```
 
 The app will be available at `http://localhost:5000`.
+
+### Configuration
+
+Open `/config` to edit teachers, students and general parameters. Teacher and
+student subjects are entered as comma separated lists. Each teacher or student
+name must be unique. The default database contains a simple setup with three
+teachers and several students to get you started.
+
+A minimal test configuration could be:
+
+```
+Teachers
+    Teacher A: Math, English
+    Teacher B: Science
+    Teacher C: History
+
+Students
+    Student 1: Math, English
+    Student 2: Math, Science
+    Student 3: History
+```
+
+With `slots_per_day=6` and `max_lessons=3` you should see a timetable after
+clicking *Generate Timetable* from the home page.

--- a/cp_sat_timetable.py
+++ b/cp_sat_timetable.py
@@ -7,40 +7,42 @@ def build_model(students, teachers, slots, min_lessons, max_lessons):
 
     Args:
         students: iterable of sqlite rows or mappings with ``id`` and ``subjects`` fields.
-        teachers: iterable of sqlite rows or mappings with ``id`` and ``subject`` fields.
+        teachers: iterable of sqlite rows or mappings with ``id`` and ``subjects`` fields.
         slots: number of discrete time slots in the day.
         min_lessons: minimum number of lessons each student should receive.
         max_lessons: maximum number of lessons each student can receive.
 
     Returns:
         model (cp_model.CpModel): The constructed model.
-        vars_ (dict): Mapping (student_id, teacher_id, slot) -> BoolVar.
+        vars_ (dict): Mapping (student_id, teacher_id, subject, slot) -> BoolVar.
     """
     model = cp_model.CpModel()
     vars_ = {}
 
-    # Create variables only for allowed (student, teacher) pairs based on subjects
+    # Create variables for allowed (student, teacher, subject) triples
     for student in students:
         student_subs = set(json.loads(student['subjects']))
         for teacher in teachers:
-            if teacher['subject'] in student_subs:
+            teacher_subs = set(json.loads(teacher['subjects']))
+            common = student_subs & teacher_subs
+            for subject in common:
                 for slot in range(slots):
-                    vars_[(student['id'], teacher['id'], slot)] = model.NewBoolVar(
-                        f"x_s{student['id']}_t{teacher['id']}_sl{slot}")
+                    vars_[(student['id'], teacher['id'], subject, slot)] = model.NewBoolVar(
+                        f"x_s{student['id']}_t{teacher['id']}_sub{subject}_sl{slot}")
 
-    # Teacher cannot teach more than one student in a slot
+    # Teacher cannot teach more than one lesson in a slot
     for teacher in teachers:
         for slot in range(slots):
-            possible = [vars_[(s['id'], teacher['id'], slot)]
-                        for s in students if (s['id'], teacher['id'], slot) in vars_]
+            possible = [var for (sid, tid, subj, sl), var in vars_.items()
+                        if tid == teacher['id'] and sl == slot]
             if possible:
                 model.Add(sum(possible) <= 1)
 
     # Student cannot attend more than one lesson in a slot
     for student in students:
         for slot in range(slots):
-            possible = [vars_[(student['id'], t['id'], slot)]
-                        for t in teachers if (student['id'], t['id'], slot) in vars_]
+            possible = [var for (sid, tid, subj, sl), var in vars_.items()
+                        if sid == student['id'] and sl == slot]
             if possible:
                 model.Add(sum(possible) <= 1)
 
@@ -49,14 +51,11 @@ def build_model(students, teachers, slots, min_lessons, max_lessons):
         total = []
         subs = json.loads(student['subjects'])
         for subject in subs:
-            subject_vars = [vars_[(student['id'], t['id'], sl)]
-                            for t in teachers if t['subject'] == subject
-                            for sl in range(slots)
-                            if (student['id'], t['id'], sl) in vars_]
+            subject_vars = [var for (sid, tid, subj, sl), var in vars_.items()
+                            if sid == student['id'] and subj == subject]
             if subject_vars:
                 model.Add(sum(subject_vars) >= 1)
                 total.extend(subject_vars)
-        # total lessons constraint
         if total:
             model.Add(sum(total) >= min_lessons)
             model.Add(sum(total) <= max_lessons)
@@ -74,8 +73,8 @@ def solve_and_print(model, vars_):
 
     assignments = []
     if status in (cp_model.OPTIMAL, cp_model.FEASIBLE):
-        for (sid, tid, slot), var in vars_.items():
+        for (sid, tid, subj, slot), var in vars_.items():
             if solver.BooleanValue(var):
-                assignments.append((sid, tid, slot))
+                assignments.append((sid, tid, subj, slot))
 
     return status, assignments

--- a/templates/config.html
+++ b/templates/config.html
@@ -21,11 +21,11 @@
             {% for t in teachers %}
             <input type="hidden" name="teacher_id" value="{{ t['id'] }}">
             <label>Name: <input type="text" name="teacher_name" value="{{ t['name'] }}"></label>
-            <label>Subject: <input type="text" name="teacher_subject" value="{{ t['subject'] }}"></label>
+            <label>Subjects: <input type="text" name="teacher_subjects" value="{{ ', '.join(json.loads(t['subjects'])) }}"></label>
             <label>Delete? <input type="checkbox" name="teacher_delete" value="{{ t['id'] }}"></label><br>
             {% endfor %}
             <label>New Name: <input type="text" name="new_teacher_name"></label>
-            <label>Subject: <input type="text" name="new_teacher_subject"></label><br>
+            <label>Subjects: <input type="text" name="new_teacher_subjects"></label><br>
         </fieldset>
         <fieldset>
             <legend>Students (comma separated subjects)</legend>

--- a/templates/timetable.html
+++ b/templates/timetable.html
@@ -11,7 +11,7 @@
         <tr>
             <th>Slot</th>
             {% for t in teachers %}
-            <th>{{ t['name'] }}<br>{{ t['subject'] }}</th>
+            <th>{{ t['name'] }}<br>{{ ', '.join(json.loads(t['subjects'])) }}</th>
             {% endfor %}
         </tr>
         {% for slot in slots %}


### PR DESCRIPTION
## Summary
- add CP-SAT schedule builder/solver
- use CP-SAT logic in `generate_schedule`

## Testing
- `pytest -q`
- `python -m py_compile app.py cp_sat_timetable.py`


------
https://chatgpt.com/codex/tasks/task_e_68799d35f8f88322b6fd13f42643fe35