### PR TITLE
Improve timetable overwrite and config validation

### DIFF
--- a/static/config.js
+++ b/static/config.js
@@ -61,11 +61,18 @@ document.addEventListener('DOMContentLoaded', function () {
         if (!tid || isNaN(slot)) return;
         const fixed = assignData[tid] || [];
         const unav = unavailData[tid] || [];
+        const flashes = document.getElementById('flash-messages');
+        if (!flashes) return;
+        const li = document.createElement('li');
+        li.className = 'error';
         if (fixed.includes(slot)) {
-            alert('Warning: fixed assignment exists in this slot.');
+            li.textContent = 'Warning: fixed assignment exists in this slot.';
         } else if (unav.includes(slot)) {
-            alert('Slot already marked unavailable.');
+            li.textContent = 'Slot already marked unavailable.';
+        } else {
+            return;
         }
+        flashes.appendChild(li);
     }
     if (unavailTeacher && unavailSlot) {
         unavailTeacher.addEventListener('change', warnUnavail);

--- a/templates/config.html
+++ b/templates/config.html
@@ -9,7 +9,7 @@
     <h1>Configuration</h1>
     {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
-    <ul class="flashes">
+    <ul id="flash-messages" class="flashes">
         {% for category, msg in messages %}
         <li class="{{ category }}">{{ msg }}</li>
         {% endfor %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
     <ul>
         <li><a href="{{ url_for('config') }}">Edit Configuration</a></li>
     </ul>
-    <form action="{{ url_for('generate') }}" method="post">
+    <form id="generate-form" action="{{ url_for('generate') }}" method="post">
         <label>Date: <input type="date" name="date" value="{{ today }}"></label>
         <button type="submit">Generate Timetable</button>
     </form>
@@ -18,5 +18,37 @@
         <label>Date: <input type="date" name="date" value="{{ today }}"></label>
         <button type="submit">View Timetable</button>
     </form>
+    <script>
+    const form = document.getElementById('generate-form');
+    const checkUrl = '{{ url_for('check_timetable') }}';
+    form.addEventListener('submit', async function(e) {
+        const dateInput = form.querySelector('input[name="date"]');
+        if (!dateInput || !dateInput.value) return;
+        e.preventDefault();
+        try {
+            const resp = await fetch(checkUrl + '?date=' + encodeURIComponent(dateInput.value));
+            const data = await resp.json();
+            let proceed = true;
+            if (data.exists) {
+                proceed = confirm('Timetable already exists for this date. Overwrite?');
+            }
+            if (proceed) {
+                if (data.exists) {
+                    let input = form.querySelector('input[name="confirm"]');
+                    if (!input) {
+                        input = document.createElement('input');
+                        input.type = 'hidden';
+                        input.name = 'confirm';
+                        input.value = '1';
+                        form.appendChild(input);
+                    }
+                }
+                form.submit();
+            }
+        } catch (err) {
+            form.submit();
+        }
+    });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- confirm before regenerating a timetable for an existing date
- add endpoint to check if a timetable exists
- stop saving config when validation fails
- show client-side config warnings in flash list

## Testing
- `python -m py_compile app.py cp_sat_timetable.py`

------
https://chatgpt.com/codex/tasks/task_e_687d841174f88322801ef33a8f4cbed5