### PR TITLE
Add group lesson weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ this value if you want the solver to focus even more on improving attendance.
 When using group lessons you can adjust **Group weight** to bias the solver
 toward scheduling them. This multiplier boosts the objective weight of any
 variable whose ``student_id`` represents a group, making joint lessons more
-appealing relative to individual ones.
+appealing relative to individual ones. A value around **2** is a good
+starting point and roughly doubles the attractiveness of group lessons.
 
 Two numbers define the minimum and maximum lessons each teacher should teach.
 Individual teachers can override these global limits. Leave the per-teacher

--- a/cp_sat_timetable.py
+++ b/cp_sat_timetable.py
@@ -41,7 +41,8 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
             used to weight variables in the objective.
         group_weight: multiplier applied to the weight of variables whose
             ``student_id`` represents a group. This biases the solver toward
-            scheduling group lessons.
+            scheduling group lessons. A value around ``2.0`` moderately favors
+            groups without overwhelming other objectives.
 
     Returns:
         model (cp_model.CpModel): The constructed model.

--- a/templates/config.html
+++ b/templates/config.html
@@ -50,6 +50,9 @@
             <label>Attendance weight:
                 <input type="number" name="attendance_weight" value="{{ config['attendance_weight'] }}" min="1">
             </label>
+            <label>Group weight:
+                <input type="number" name="group_weight" value="{{ config['group_weight'] }}" min="1" step="0.1">
+            </label>
         </fieldset>
         <fieldset>
             <legend>Subjects</legend>


### PR DESCRIPTION
## Summary
- bias group lessons with a new `group_weight` parameter
- describe the weight in the `build_model` docstring
- update README with a note on the group weight setting

## Testing
- `python -m py_compile cp_sat_timetable.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_687e318a80e08322ab739052dfec8a30