### PR TITLE
Implement teacher exclusion for students

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A local-first, browser-based school timetabling application built with **Python 
 ## 💡 Key Features
 
 - Configure teachers, students and lesson constraints
+- Specify teachers that individual students should avoid
 - Generate optimized, conflict-free timetables
 - Simple web interface, no external database setup
 - Attendance report showing how often each student attended each subject. History

--- a/templates/config.html
+++ b/templates/config.html
@@ -108,6 +108,13 @@
                 </select>
             </label>
             <label>Needs lessons? <input type="checkbox" name="student_active_{{ s['id'] }}" value="1" {% if s['active'] %}checked{% endif %}></label>
+            <label>Forbidden Teachers:
+                <select multiple name="student_block_{{ s['id'] }}">
+                    {% for t in teachers %}
+                    <option value="{{ t['id'] }}" {% if t['id'] in block_map.get(s['id'], []) %}selected{% endif %}>{{ t['name'] }}</option>
+                    {% endfor %}
+                </select>
+            </label>
             <label>Delete? <input type="checkbox" name="student_delete_{{ s['id'] }}" value="1"></label><br>
             {% endfor %}
             <label>New Name: <input type="text" name="new_student_name"></label>
@@ -115,6 +122,13 @@
                 <select multiple name="new_student_subjects">
                     {% for sub in subjects %}
                     <option value="{{ sub['name'] }}">{{ sub['name'] }}</option>
+                    {% endfor %}
+                </select>
+            </label>
+            <label>Forbidden Teachers:
+                <select multiple name="new_student_block">
+                    {% for t in teachers %}
+                    <option value="{{ t['id'] }}">{{ t['name'] }}</option>
                     {% endfor %}
                 </select>
             </label><br>


### PR DESCRIPTION
## Summary
- allow configuring which teachers a student must avoid
- propagate these restrictions to groups
- skip variable creation for blocked student-teacher pairs
- document the new configuration capability

## Testing
- `python -m py_compile app.py cp_sat_timetable.py`
- `pip install flask ortools`
- `python app.py` *(started server)*

------
https://chatgpt.com/codex/tasks/task_e_687e451d8fbc8322aed929e3b1d68ce5