### PR TITLE
Add timetable management and layout fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A local-first, browser-based school timetabling application built with **Python 
 - Attendance report showing how often each student attended each subject. History
   is tied to the numeric `student_id`; deleting a student and re-adding one with
   the same name creates a new ID and past attendance is not merged.
+- Delete saved timetables individually or clear them all at once.
 
 ## 📦 Project Structure
 

--- a/templates/config.html
+++ b/templates/config.html
@@ -52,16 +52,16 @@
             </label><br>
             <label>Attendance weight:
                 <input type="number" name="attendance_weight" value="{{ config['attendance_weight'] }}" min="1">
-            </label>
+            </label><br>
             <label>Group weight:
                 <input type="number" name="group_weight" value="{{ config['group_weight'] }}" min="1" step="0.1">
-            </label>
+            </label><br>
             <label>Balance teacher load?
                 <input type="checkbox" name="balance_teacher_load" {% if config['balance_teacher_load'] %}checked{% endif %}>
-            </label>
+            </label><br>
             <label>Balance weight:
                 <input type="number" name="balance_weight" value="{{ config['balance_weight'] }}" min="1">
-            </label>
+            </label><br>
         </fieldset>
         <fieldset>
             <legend>Subjects</legend>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,7 @@
     <ul>
         <li><a href="{{ url_for('config') }}">Edit Configuration</a></li>
         <li><a href="{{ url_for('attendance') }}">View Attendance</a></li>
+        <li><a href="{{ url_for('manage_timetables') }}">Manage Timetables</a></li>
     </ul>
     <form id="generate-form" action="{{ url_for('generate') }}" method="post">
         <label>Date: <input type="date" name="date" value="{{ today }}"></label>

--- a/templates/manage_timetables.html
+++ b/templates/manage_timetables.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Manage Timetables</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h1>Manage Saved Timetables</h1>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+    <ul class="flashes">
+        {% for category, msg in messages %}
+        <li class="{{ category }}">{{ msg }}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+    {% endwith %}
+    {% if dates %}
+    <form method="post" action="{{ url_for('delete_timetables') }}" id="delete-form" onsubmit="return confirm('Delete selected timetables?');">
+        <table>
+            <tr><th>Date</th><th>Select</th></tr>
+            {% for d in dates %}
+            <tr>
+                <td>{{ d }}</td>
+                <td><input type="checkbox" name="dates" value="{{ d }}"></td>
+            </tr>
+            {% endfor %}
+        </table>
+        <button type="submit">Delete Selected</button>
+    </form>
+    <form method="post" action="{{ url_for('delete_timetables') }}" onsubmit="return confirm('Delete all timetables?');">
+        <input type="hidden" name="clear_all" value="1">
+        <button type="submit">Clear All</button>
+    </form>
+    {% else %}
+    <p>No timetables saved.</p>
+    {% endif %}
+    <p><a href="{{ url_for('index') }}">Home</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- make group weight and load balancing options each appear on separate lines in the config page
- document new ability to delete saved timetables
- add Manage Timetables page and link on home page
- support deleting selected timetable dates or clearing all

## Testing
- `python -m py_compile app.py cp_sat_timetable.py`
- `flake8` *(fails: E501 line too long)*
- `python app.py` *(started server successfully)*

------
https://chatgpt.com/codex/tasks/task_e_687e60385b988322a6be4969424dc266