### PR TITLE
Improve assumption handling for blocked teachers

### DIFF
--- a/app.py
+++ b/app.py
@@ -799,7 +799,7 @@ def generate_schedule(target_date=None):
             # Map assumption literals from the unsat core to human readable
             # messages explaining why the model is infeasible.
             reason_map = {
-                'teacher_availability': 'A teacher is unavailable for a required slot.',
+                'teacher_availability': 'A teacher is unavailable or blocked for a required lesson.',
                 'teacher_limits': 'Teacher lesson limits are too strict.',
                 'student_limits': 'Student lesson or subject requirements conflict.',
                 'repeat_restrictions': 'Repeat or consecutive lesson restrictions prevent a schedule.',


### PR DESCRIPTION
## Summary
- include teacher blocking in the teacher availability assumption
- document updated assumption semantics
- clarify error message when a teacher is blocked

## Testing
- `python -m py_compile cp_sat_timetable.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_687f5af855b08322b0687f455c01c931