### PR TITLE
Move inline JS to static files

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -1,0 +1,65 @@
+// Site-wide JavaScript helpers
+
+document.addEventListener('DOMContentLoaded', function () {
+    // Timetable overwrite check on the index page
+    const generateForm = document.getElementById('generate-form');
+    if (generateForm) {
+        const checkUrl = generateForm.dataset.checkUrl;
+        generateForm.addEventListener('submit', async function (e) {
+            const dateInput = generateForm.querySelector('input[name="date"]');
+            if (!dateInput || !dateInput.value || !checkUrl) return;
+            e.preventDefault();
+            try {
+                const resp = await fetch(checkUrl + '?date=' + encodeURIComponent(dateInput.value));
+                const data = await resp.json();
+                let proceed = true;
+                if (data.exists) {
+                    proceed = confirm('Timetable already exists for this date. Overwrite?');
+                }
+                if (proceed) {
+                    if (data.exists) {
+                        let input = generateForm.querySelector('input[name="confirm"]');
+                        if (!input) {
+                            input = document.createElement('input');
+                            input.type = 'hidden';
+                            input.name = 'confirm';
+                            input.value = '1';
+                            generateForm.appendChild(input);
+                        }
+                    }
+                    generateForm.submit();
+                }
+            } catch (err) {
+                generateForm.submit();
+            }
+        });
+    }
+
+    // Confirmation prompts for destructive actions
+    const resetForm = document.getElementById('reset-db-form');
+    if (resetForm) {
+        resetForm.addEventListener('submit', function (e) {
+            if (!confirm('This will erase all data and reset to defaults. Continue?')) {
+                e.preventDefault();
+            }
+        });
+    }
+
+    const deleteForm = document.getElementById('delete-form');
+    if (deleteForm) {
+        deleteForm.addEventListener('submit', function (e) {
+            if (!confirm('Delete selected timetables?')) {
+                e.preventDefault();
+            }
+        });
+    }
+
+    const clearAllForm = document.getElementById('clear-all-form');
+    if (clearAllForm) {
+        clearAllForm.addEventListener('submit', function (e) {
+            if (!confirm('Delete all timetables?')) {
+                e.preventDefault();
+            }
+        });
+    }
+});

--- a/static/ui.js
+++ b/static/ui.js
@@ -1,0 +1,7 @@
+// UI component initialisation for Tailwind/Flowbite
+
+document.addEventListener('DOMContentLoaded', function () {
+    if (window.initFlowbite) {
+        try { initFlowbite(); } catch (e) { /* ignore errors if flowbite unavailable */ }
+    }
+});

--- a/templates/config.html
+++ b/templates/config.html
@@ -249,7 +249,7 @@
         <button type="submit">Save</button>
     </form>
 
-    <form method="post" action="{{ url_for('reset_db') }}" onsubmit="return confirm('This will erase all data and reset to defaults. Continue?');">
+    <form method="post" action="{{ url_for('reset_db') }}" id="reset-db-form">
         <button type="submit">Reset Database</button>
     </form>
     <p><a href="{{ url_for('index') }}">Back to Home</a></p>
@@ -261,5 +261,7 @@
     <script id="assign-data" type="application/json">{{ assign_map | tojson }}</script>
     <script id="slot-times-data" type="application/json">{{ slot_times | tojson }}</script>
     <script src="{{ url_for('static', filename='config.js') }}"></script>
+    <script src="{{ url_for('static', filename='ui.js') }}"></script>
+    <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,7 +13,7 @@
         <li><a href="{{ url_for('attendance') }}">View Attendance</a></li>
         <li><a href="{{ url_for('manage_timetables') }}">Manage Timetables</a></li>
     </ul>
-    <form id="generate-form" action="{{ url_for('generate') }}" method="post">
+    <form id="generate-form" action="{{ url_for('generate') }}" method="post" data-check-url="{{ url_for('check_timetable') }}">
         <label>Date: <input type="date" name="date" value="{{ today }}"></label>
         <button type="submit">Generate Timetable</button>
     </form>
@@ -22,38 +22,6 @@
         <button type="submit">View Timetable</button>
 <!-- Form posts to /generate; JavaScript warns if a timetable already exists -->
     </form>
-    <!-- check_timetable is called via fetch() before submitting -->
-    <script>
-    const form = document.getElementById('generate-form');
-    const checkUrl = '{{ url_for('check_timetable') }}';
-    form.addEventListener('submit', async function(e) {
-        const dateInput = form.querySelector('input[name="date"]');
-        if (!dateInput || !dateInput.value) return;
-        e.preventDefault();
-        try {
-            const resp = await fetch(checkUrl + '?date=' + encodeURIComponent(dateInput.value));
-            const data = await resp.json();
-            let proceed = true;
-            if (data.exists) {
-                proceed = confirm('Timetable already exists for this date. Overwrite?');
-            }
-            if (proceed) {
-                if (data.exists) {
-                    let input = form.querySelector('input[name="confirm"]');
-                    if (!input) {
-                        input = document.createElement('input');
-                        input.type = 'hidden';
-                        input.name = 'confirm';
-                        input.value = '1';
-                        form.appendChild(input);
-                    }
-                }
-                form.submit();
-            }
-        } catch (err) {
-            form.submit();
-        }
-    });
-    </script>
+    <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
 </html>

--- a/templates/manage_timetables.html
+++ b/templates/manage_timetables.html
@@ -18,7 +18,7 @@
     {% endif %}
     {% endwith %}
     {% if dates %}
-    <form method="post" action="{{ url_for('delete_timetables') }}" id="delete-form" onsubmit="return confirm('Delete selected timetables?');">
+    <form method="post" action="{{ url_for('delete_timetables') }}" id="delete-form">
         <table>
             <tr><th>Date</th><th>Select</th></tr>
             {% for d in dates %}
@@ -30,7 +30,7 @@
         </table>
         <button type="submit">Delete Selected</button>
     </form>
-    <form method="post" action="{{ url_for('delete_timetables') }}" onsubmit="return confirm('Delete all timetables?');">
+    <form method="post" action="{{ url_for('delete_timetables') }}" id="clear-all-form">
         <input type="hidden" name="clear_all" value="1">
         <button type="submit">Clear All</button>
     </form>
@@ -38,5 +38,7 @@
     <p>No timetables saved.</p>
     {% endif %}
     <p><a href="{{ url_for('index') }}">Home</a></p>
+    <script src="{{ url_for('static', filename='ui.js') }}"></script>
+    <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create site-wide `static/main.js`
- add `static/ui.js` for Flowbite helpers
- refactor templates to use the new scripts and remove inline JS/confirm attributes

## Testing
- `python -m py_compile app.py cp_sat_timetable.py`

------
https://chatgpt.com/codex/tasks/task_e_687fa38d14a083229930a4962060fa72