### PR TITLE
Update Flowbite datepicker usage

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -4,11 +4,4 @@ document.addEventListener('DOMContentLoaded', function () {
     if (window.initFlowbite) {
         try { initFlowbite(); } catch (e) { /* ignore errors if flowbite unavailable */ }
     }
-    if (window.Datepicker) {
-        const opts = { autohide: true, format: 'yyyy-mm-dd' };
-        const gen = document.getElementById('generate-date');
-        if (gen) new Datepicker(gen, opts);
-        const view = document.getElementById('view-date');
-        if (view) new Datepicker(view, opts);
-    }
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
     <title>Timetabling App</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/1.6.0/flowbite.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css">
 </head>
 <body class="bg-gray-100 min-h-screen">
     <div class="max-w-xl mx-auto mt-10 p-6 bg-white rounded-xl shadow">
@@ -18,20 +18,30 @@
         </ul>
         <form id="generate-form" action="{{ url_for('generate') }}" method="post" data-check-url="{{ url_for('check_timetable') }}" class="mb-4">
             <label class="block mb-2">Date:
-                <input id="generate-date" class="rounded-lg border border-gray-300 px-3 py-2 w-full" type="text" name="date" value="{{ today }}" placeholder="Select date">
+                <div class="relative">
+                    <div class="absolute inset-y-0 left-0 flex items-center pl-3.5 pointer-events-none">
+                        <svg aria-hidden="true" class="w-4 h-4 text-gray-500 dark:text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20"><path d="M6 2a1 1 0 011 1v1h6V3a1 1 0 112 0v1h1a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V6a2 2 0 012-2h1V3a1 1 0 011-1z"/><path d="M3 8h14v9H3V8z"/></svg>
+                    </div>
+                    <input datepicker datepicker-format="yyyy-mm-dd" datepicker-autohide="true" id="generate-date" class="border border-gray-300 rounded-lg block w-full pl-10 p-2.5" type="text" name="date" value="{{ today }}" placeholder="Select date">
+                </div>
             </label>
             <button type="submit" class="w-full bg-blue-500 text-white border rounded-md px-3 py-2 hover:bg-blue-600 transition">Generate Timetable</button>
         </form>
         <form action="{{ url_for('timetable') }}" method="get" class="mb-2">
             <label class="block mb-2">Date:
-                <input id="view-date" class="rounded-lg border border-gray-300 px-3 py-2 w-full" type="text" name="date" value="{{ today }}" placeholder="Select date">
+                <div class="relative">
+                    <div class="absolute inset-y-0 left-0 flex items-center pl-3.5 pointer-events-none">
+                        <svg aria-hidden="true" class="w-4 h-4 text-gray-500 dark:text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20"><path d="M6 2a1 1 0 011 1v1h6V3a1 1 0 112 0v1h1a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V6a2 2 0 012-2h1V3a1 1 0 011-1z"/><path d="M3 8h14v9H3V8z"/></svg>
+                    </div>
+                    <input datepicker datepicker-format="yyyy-mm-dd" datepicker-autohide="true" id="view-date" class="border border-gray-300 rounded-lg block w-full pl-10 p-2.5" type="text" name="date" value="{{ today }}" placeholder="Select date">
+                </div>
             </label>
             <button type="submit" class="w-full bg-green-500 text-white border rounded-md px-3 py-2 hover:bg-green-600 transition">View Timetable</button>
         </form>
         <!-- Form posts to /generate; JavaScript warns if a timetable already exists -->
     </div>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/1.6.0/flowbite.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/1.6.0/datepicker.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/datepicker.min.js"></script>
     <script src="{{ url_for('static', filename='ui.js') }}"></script>
     <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>


### PR DESCRIPTION
## Summary
- upgrade Flowbite CDN links
- apply Flowbite datepicker attributes with icons
- simplify datepicker initialization in JS

## Testing
- `python -m py_compile app.py cp_sat_timetable.py`


------
https://chatgpt.com/codex/tasks/task_e_688030fb029c83229ebd4b9fe8641833