### PR TITLE
Remove outer card from home page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css">
 </head>
 <body class="bg-gray-100 min-h-screen">
-    <div class="max-w-2xl mx-auto mt-10 p-6 bg-white rounded-xl shadow">
+    <div class="max-w-2xl mx-auto mt-10 p-6">
         <h1 class="text-2xl font-semibold mb-4 text-center">Welcome to the Timetabling App</h1>
         <ul class="flex justify-center text-sm font-medium text-center text-gray-500 border-b border-gray-200 dark:text-gray-400 dark:border-gray-700 mb-6" role="tablist">
             <li class="me-2">


### PR DESCRIPTION
## Summary
- keep two cards for actions but remove surrounding card from `index.html`

## Testing
- `python -m py_compile app.py cp_sat_timetable.py`


------
https://chatgpt.com/codex/tasks/task_e_688056db453c8322b4d0a95935107824