### PR TITLE
Display timetable results on home page

### DIFF
--- a/app.py
+++ b/app.py
@@ -281,8 +281,11 @@ def index():
         data = get_timetable_data(selected)
         (sel_date, slots, teachers, grid, missing,
          student_names, slot_labels, has_rows) = data
+        if not has_rows:
+            flash('No timetable available. Generate one from the home page.',
+                  'error')
         context.update({
-            'show_timetable': True,
+            'show_timetable': has_rows,
             'date': sel_date,
             'slots': slots,
             'teachers': teachers,

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,6 +11,15 @@
 <body class="bg-gray-100 min-h-screen">
     <div class="max-w-2xl mx-auto mt-10 p-6">
         <h1 class="text-2xl font-semibold mb-4 text-center">Welcome to the Timetabling App</h1>
+        {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+        <ul class="flashes mb-4 text-center">
+            {% for category, msg in messages %}
+            <li class="{{ category }}">{{ msg }}</li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+        {% endwith %}
         <ul class="flex justify-center text-sm font-medium text-center text-gray-500 border-b border-gray-200 dark:text-gray-400 dark:border-gray-700 mb-6" role="tablist">
             <li class="me-2">
                 <a href="{{ url_for('index') }}" class="inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300">Home</a>
@@ -62,6 +71,7 @@
         {% if show_timetable %}
         <div class="mt-6">
             <h2 class="text-lg font-medium mb-2 text-center">Timetable for {{ date }}</h2>
+            {% if has_rows %}
             <div class="overflow-x-auto">
                 <table class="w-full text-sm text-left text-gray-500 dark:text-gray-400">
                     <thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
@@ -94,6 +104,9 @@
                 <li>{{ student_names[sid] }}: {{ ', '.join(subs) }}</li>
                 {% endfor %}
             </ul>
+            {% endif %}
+            {% else %}
+            <p class="text-center text-red-600">No timetable available. Generate one from the home page.</p>
             {% endif %}
         </div>
         {% endif %}


### PR DESCRIPTION
## Summary
- show navigation Home tab
- load a timetable in the index route when a date is provided
- reuse `get_timetable_data` helper for timetable pages
- use Flowbite-styled table embedded under the forms on the home page
- redirect generation to index with selected date

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68805c58bca883229e4697baca1dd8f7