### PR TITLE
Enhance manage & attendance pages with Flowbite styles

### DIFF
--- a/templates/attendance.html
+++ b/templates/attendance.html
@@ -5,52 +5,85 @@
     <meta charset="UTF-8">
     <title>Attendance Report</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css">
 </head>
-<body>
-    <h1>Attendance Report</h1>
-    <h2>Active Students</h2>
-    <table border="1" cellpadding="5">
-        <tr>
-            <th>Student</th>
-            <th>Subject</th>
-            <th>Lessons</th>
-            <th>Percentage</th>
-        </tr>
-        {% for sid, info in active_attendance.items() %}
-            {% for subject, stats in info.subjects.items() %}
-        <tr>
-            <td>{{ info.name }}</td>
-            <td>{{ subject }}</td>
-            <td>{{ stats.count }}</td>
-            <td>{{ '%.2f'|format(stats.percentage) }}%</td>
-        </tr>
-            {% endfor %}
-        {% endfor %}
-    </table>
+<body class="bg-emerald-50 min-h-screen">
+    <div class="max-w-2xl mx-auto mt-10 p-6">
+        <h1 class="text-2xl text-emerald-900 font-semibold mb-4 text-center">Attendance Report</h1>
+        <ul class="flex justify-center text-sm font-medium text-center text-emerald-700 border-b border-emerald-200 dark:text-emerald-300 dark:border-emerald-700 mb-6" role="tablist">
+            <li class="me-2">
+                <a href="{{ url_for('index') }}" class="inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-emerald-600 hover:border-emerald-300 dark:hover:text-emerald-300">Home</a>
+            </li>
+            <li class="me-2">
+                <a href="{{ url_for('config') }}" class="inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-emerald-600 hover:border-emerald-300 dark:hover:text-emerald-300">Edit Configuration</a>
+            </li>
+            <li class="me-2">
+                <a href="{{ url_for('attendance') }}" class="inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-emerald-600 hover:border-emerald-300 dark:hover:text-emerald-300">View Attendance</a>
+            </li>
+            <li class="me-2">
+                <a href="{{ url_for('manage_timetables') }}" class="inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-emerald-600 hover:border-emerald-300 dark:hover:text-emerald-300">Manage Timetables</a>
+            </li>
+        </ul>
+        <h2 class="text-lg font-medium mb-2">Active Students</h2>
+        <div class="overflow-x-auto mb-6">
+        <table class="w-full text-sm text-left text-emerald-700 dark:text-emerald-300 rounded-lg border border-emerald-200 overflow-hidden dark:border-emerald-700">
+            <thead class="text-xs text-emerald-800 uppercase bg-emerald-100 dark:bg-emerald-800 dark:text-emerald-200">
+                <tr>
+                    <th scope="col" class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">Student</th>
+                    <th scope="col" class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">Subject</th>
+                    <th scope="col" class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">Lessons</th>
+                    <th scope="col" class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">Percentage</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for sid, info in active_attendance.items() %}
+                    {% for subject, stats in info.subjects.items() %}
+                <tr class="bg-white border-b border-emerald-100 dark:bg-emerald-900 dark:border-emerald-700">
+                    <td class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">{{ info.name }}</td>
+                    <td class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">{{ subject }}</td>
+                    <td class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">{{ stats.count }}</td>
+                    <td class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">{{ '%.2f'|format(stats.percentage) }}%</td>
+                </tr>
+                    {% endfor %}
+                {% endfor %}
+            </tbody>
+        </table>
+        </div>
 
-    <h2>Deleted Students</h2>
-    <table border="1" cellpadding="5">
-        <tr>
-            <th>Student</th>
-            <th>Subject</th>
-            <th>Lessons</th>
-            <th>Percentage</th>
-            <th>First Date</th>
-            <th>Last Date</th>
-        </tr>
-        {% for sid, info in deleted_attendance.items() %}
-            {% for subject, stats in info.subjects.items() %}
-        <tr>
-            <td>{{ info.name }}</td>
-            <td>{{ subject }}</td>
-            <td>{{ stats.count }}</td>
-            <td>{{ '%.2f'|format(stats.percentage) }}%</td>
-            <td>{{ info.first_date }}</td>
-            <td>{{ info.last_date }}</td>
-        </tr>
-            {% endfor %}
-        {% endfor %}
-    </table>
-    <p><a href="{{ url_for('index') }}">Home</a></p>
+        <h2 class="text-lg font-medium mb-2">Deleted Students</h2>
+        <div class="overflow-x-auto mb-6">
+        <table class="w-full text-sm text-left text-emerald-700 dark:text-emerald-300 rounded-lg border border-emerald-200 overflow-hidden dark:border-emerald-700">
+            <thead class="text-xs text-emerald-800 uppercase bg-emerald-100 dark:bg-emerald-800 dark:text-emerald-200">
+                <tr>
+                    <th scope="col" class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">Student</th>
+                    <th scope="col" class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">Subject</th>
+                    <th scope="col" class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">Lessons</th>
+                    <th scope="col" class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">Percentage</th>
+                    <th scope="col" class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">First Date</th>
+                    <th scope="col" class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">Last Date</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for sid, info in deleted_attendance.items() %}
+                    {% for subject, stats in info.subjects.items() %}
+                <tr class="bg-white border-b border-emerald-100 dark:bg-emerald-900 dark:border-emerald-700">
+                    <td class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">{{ info.name }}</td>
+                    <td class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">{{ subject }}</td>
+                    <td class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">{{ stats.count }}</td>
+                    <td class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">{{ '%.2f'|format(stats.percentage) }}%</td>
+                    <td class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">{{ info.first_date }}</td>
+                    <td class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">{{ info.last_date }}</td>
+                </tr>
+                    {% endfor %}
+                {% endfor %}
+            </tbody>
+        </table>
+        </div>
+        <p class="text-center"><a href="{{ url_for('index') }}" class="text-emerald-700 underline">Home</a></p>
+    </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.js"></script>
+    <script src="{{ url_for('static', filename='ui.js') }}"></script>
+    <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
 </html>

--- a/templates/manage_timetables.html
+++ b/templates/manage_timetables.html
@@ -5,39 +5,68 @@
     <meta charset="UTF-8">
     <title>Manage Timetables</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css">
 </head>
-<body>
-    <h1>Manage Saved Timetables</h1>
-    {% with messages = get_flashed_messages(with_categories=true) %}
-    {% if messages %}
-    <ul class="flashes">
-        {% for category, msg in messages %}
-        <li class="{{ category }}">{{ msg }}</li>
-        {% endfor %}
-    </ul>
-    {% endif %}
-    {% endwith %}
-    {% if dates %}
-    <form method="post" action="{{ url_for('delete_timetables') }}" id="delete-form">
-        <table>
-            <tr><th>Date</th><th>Select</th></tr>
-            {% for d in dates %}
-            <tr>
-                <td>{{ d }}</td>
-                <td><input type="checkbox" name="dates" value="{{ d }}"></td>
-            </tr>
+<body class="bg-emerald-50 min-h-screen">
+    <div class="max-w-2xl mx-auto mt-10 p-6">
+        <h1 class="text-2xl text-emerald-900 font-semibold mb-4 text-center">Manage Saved Timetables</h1>
+        {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+        <ul class="flashes mb-4 text-center">
+            {% for category, msg in messages %}
+            <li class="{{ category }}">{{ msg }}</li>
             {% endfor %}
-        </table>
-        <button type="submit">Delete Selected</button>
-    </form>
-    <form method="post" action="{{ url_for('delete_timetables') }}" id="clear-all-form">
-        <input type="hidden" name="clear_all" value="1">
-        <button type="submit">Clear All</button>
-    </form>
-    {% else %}
-    <p>No timetables saved.</p>
-    {% endif %}
-    <p><a href="{{ url_for('index') }}">Home</a></p>
+        </ul>
+        {% endif %}
+        {% endwith %}
+        <ul class="flex justify-center text-sm font-medium text-center text-emerald-700 border-b border-emerald-200 dark:text-emerald-300 dark:border-emerald-700 mb-6" role="tablist">
+            <li class="me-2">
+                <a href="{{ url_for('index') }}" class="inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-emerald-600 hover:border-emerald-300 dark:hover:text-emerald-300">Home</a>
+            </li>
+            <li class="me-2">
+                <a href="{{ url_for('config') }}" class="inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-emerald-600 hover:border-emerald-300 dark:hover:text-emerald-300">Edit Configuration</a>
+            </li>
+            <li class="me-2">
+                <a href="{{ url_for('attendance') }}" class="inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-emerald-600 hover:border-emerald-300 dark:hover:text-emerald-300">View Attendance</a>
+            </li>
+            <li class="me-2">
+                <a href="{{ url_for('manage_timetables') }}" class="inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-emerald-600 hover:border-emerald-300 dark:hover:text-emerald-300">Manage Timetables</a>
+            </li>
+        </ul>
+        {% if dates %}
+        <form method="post" action="{{ url_for('delete_timetables') }}" id="delete-form" class="mb-4">
+            <div class="overflow-x-auto mb-4">
+                <table class="w-full text-sm text-left text-emerald-700 dark:text-emerald-300 rounded-lg border border-emerald-200 overflow-hidden dark:border-emerald-700">
+                    <thead class="text-xs text-emerald-800 uppercase bg-emerald-100 dark:bg-emerald-800 dark:text-emerald-200">
+                        <tr>
+                            <th scope="col" class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">Date</th>
+                            <th scope="col" class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">Select</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for d in dates %}
+                        <tr class="bg-white border-b border-emerald-100 dark:bg-emerald-900 dark:border-emerald-700">
+                            <td class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">{{ d }}</td>
+                            <td class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">
+                                <input type="checkbox" name="dates" value="{{ d }}" class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500 dark:focus:ring-emerald-500 dark:ring-offset-emerald-800 focus:ring-2 dark:bg-emerald-700 dark:border-emerald-600">
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            <button type="submit" class="bg-emerald-500 text-white border rounded-md px-3 py-2 hover:bg-emerald-600 transition">Delete Selected</button>
+        </form>
+        <form method="post" action="{{ url_for('delete_timetables') }}" id="clear-all-form">
+            <input type="hidden" name="clear_all" value="1">
+            <button type="submit" class="bg-emerald-500 text-white border rounded-md px-3 py-2 hover:bg-emerald-600 transition">Clear All</button>
+        </form>
+        {% else %}
+        <p class="text-center">No timetables saved.</p>
+        {% endif %}
+    </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.js"></script>
     <script src="{{ url_for('static', filename='ui.js') }}"></script>
     <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>


### PR DESCRIPTION
## Summary
- add Tailwind and Flowbite to manage timetable and attendance views
- include navigation tabs on both pages
- style tables using Flowbite classes with emerald colours
- update checkboxes and buttons to match Flowbite look

## Testing
- `python -m py_compile app.py cp_sat_timetable.py`


------
https://chatgpt.com/codex/tasks/task_e_688099698b708322889741cb2bc987ea