### PR TITLE
Add Flowbite DataTable support

### DIFF
--- a/static/attendance.js
+++ b/static/attendance.js
@@ -8,6 +8,6 @@ document.addEventListener('DOMContentLoaded', () => {
             table: "w-full text-sm text-left text-emerald-700"
         }
     };
-    new simpleDatatables.DataTable('#active-table', options);
-    new simpleDatatables.DataTable('#deleted-table', options);
+    new DataTable('#active-table', options);
+    new DataTable('#deleted-table', options);
 });

--- a/templates/attendance.html
+++ b/templates/attendance.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/simple-datatables@latest/dist/style.css">
 </head>
 <body class="bg-emerald-50 min-h-screen">
     <div class="max-w-2xl mx-auto mt-10 p-6">


### PR DESCRIPTION
## Summary
- give attendance tables IDs so JS can target them
- initialise Flowbite DataTable on both tables
- load DataTable plugin and new script

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6880a00d74b88322b38efd2512c503a7