### PR TITLE
Handle conflicts when blocking teachers

### DIFF
--- a/app.py
+++ b/app.py
@@ -298,6 +298,25 @@ def index():
         })
     return render_template('index.html', **context)
 
+# Helper used when validating student-teacher blocks
+# Returns True if blocking is allowed, otherwise False.
+def block_allowed(student_id, teacher_id, teacher_map, student_groups,
+                  group_members, group_subj_map, block_map, fixed_pairs):
+    if (student_id, teacher_id) in fixed_pairs:
+        return False
+    tmp_map = {sid: set(tids) for sid, tids in block_map.items()}
+    tmp_map.setdefault(student_id, set()).add(teacher_id)
+    for gid in student_groups.get(student_id, []):
+        members = group_members.get(gid, [])
+        for subj in group_subj_map.get(gid, []):
+            avail = []
+            for tid, subs in teacher_map.items():
+                if subj in subs and all(tid not in tmp_map.get(m, set()) for m in members):
+                    avail.append(tid)
+            if len(avail) == 1 and avail[0] == teacher_id:
+                return False
+    return True
+
 
 @app.route('/config', methods=['GET', 'POST'])
 def config():
@@ -442,6 +461,28 @@ def config():
                 c.execute('INSERT INTO teachers (name, subjects, min_lessons, max_lessons) VALUES (?, ?, ?, ?)',
                           (new_tname, subj_json, min_val, max_val))
 
+        # load current groups and fixed assignments for block validation
+        c.execute('SELECT id, subjects FROM teachers')
+        trows = c.fetchall()
+        teacher_map_block = {t['id']: json.loads(t['subjects']) for t in trows}
+        c.execute('SELECT group_id, student_id FROM group_members')
+        gm_rows = c.fetchall()
+        group_members_block = {}
+        student_groups_block = {}
+        for gm in gm_rows:
+            group_members_block.setdefault(gm['group_id'], []).append(gm['student_id'])
+            student_groups_block.setdefault(gm['student_id'], []).append(gm['group_id'])
+        c.execute('SELECT id, subjects FROM groups')
+        g_rows = c.fetchall()
+        group_subj_map_block = {g['id']: json.loads(g['subjects']) for g in g_rows}
+        c.execute('SELECT student_id, teacher_id FROM student_teacher_block')
+        br_rows = c.fetchall()
+        block_map_current = {}
+        for r in br_rows:
+            block_map_current.setdefault(r['student_id'], set()).add(r['teacher_id'])
+        c.execute('SELECT teacher_id, student_id FROM fixed_assignments WHERE student_id IS NOT NULL')
+        fr_rows = c.fetchall()
+        fixed_pairs = {(r['student_id'], r['teacher_id']) for r in fr_rows}
         # update students
         student_ids = request.form.getlist('student_id')
         for sid in student_ids:
@@ -472,9 +513,18 @@ def config():
                           (name, subj_json, active, int(sid)))
                 blocks = request.form.getlist(f'student_block_{sid}')
                 c.execute('DELETE FROM student_teacher_block WHERE student_id=?', (int(sid),))
+                block_map_current[int(sid)] = set()
                 for tid in blocks:
+                    tval = int(tid)
+                    if not block_allowed(int(sid), tval, teacher_map_block, student_groups_block,
+                                           group_members_block, group_subj_map_block,
+                                           block_map_current, fixed_pairs):
+                        flash('Cannot block selected teacher for student', 'error')
+                        has_error = True
+                        continue
                     c.execute('INSERT INTO student_teacher_block (student_id, teacher_id) VALUES (?, ?)',
-                              (int(sid), int(tid)))
+                              (int(sid), tval))
+                    block_map_current.setdefault(int(sid), set()).add(tval)
         new_sname = request.form.get('new_student_name')
         new_ssubs = request.form.getlist('new_student_subjects')
         new_blocks = request.form.getlist('new_student_block')
@@ -483,9 +533,18 @@ def config():
             c.execute('INSERT INTO students (name, subjects, active) VALUES (?, ?, 1)',
                       (new_sname, subj_json))
             new_sid = c.lastrowid
+            block_map_current[new_sid] = set()
             for tid in new_blocks:
+                tval = int(tid)
+                if not block_allowed(new_sid, tval, teacher_map_block, student_groups_block,
+                                       group_members_block, group_subj_map_block,
+                                       block_map_current, fixed_pairs):
+                    flash('Cannot block selected teacher for student', 'error')
+                    has_error = True
+                    continue
                 c.execute('INSERT INTO student_teacher_block (student_id, teacher_id) VALUES (?, ?)',
-                          (new_sid, int(tid)))
+                          (new_sid, tval))
+                block_map_current.setdefault(new_sid, set()).add(tval)
 
         # maps used for group validation
         c.execute('SELECT id, subjects FROM teachers')

--- a/tests/test_block_rules.py
+++ b/tests/test_block_rules.py
@@ -1,0 +1,58 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import sqlite3
+import json
+import app
+
+
+def setup_db(tmp_path):
+    db_path = tmp_path / "test.db"
+    app.DB_PATH = str(db_path)
+    app.init_db()
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def test_block_teacher_fixed_assignment(tmp_path, monkeypatch):
+    conn = setup_db(tmp_path)
+    # teacher 1 teaches Math, student 1 requires Math
+    conn.execute(
+        "INSERT INTO fixed_assignments (teacher_id, student_id, group_id, subject, slot)"
+        " VALUES (1, 1, NULL, 'Math', 0)"
+    )
+    conn.commit()
+
+    c = conn.cursor()
+    c.execute('SELECT id, subjects FROM teachers')
+    teacher_map = {r[0]: json.loads(r[1]) for r in c.fetchall()}
+    c.execute('SELECT group_id, student_id FROM group_members')
+    rows = c.fetchall()
+    group_members = {}
+    student_groups = {}
+    for gid, sid in rows:
+        group_members.setdefault(gid, []).append(sid)
+        student_groups.setdefault(sid, []).append(gid)
+    c.execute('SELECT id, subjects FROM groups')
+    group_subj_map = {r[0]: json.loads(r[1]) for r in c.fetchall()}
+    c.execute('SELECT student_id, teacher_id FROM student_teacher_block')
+    br = c.fetchall()
+    block_map = {}
+    for sid, tid in br:
+        block_map.setdefault(sid, set()).add(tid)
+    c.execute('SELECT teacher_id, student_id FROM fixed_assignments WHERE student_id IS NOT NULL')
+    fixed_pairs = {(r[1], r[0]) for r in c.fetchall()}
+
+    allowed = app.block_allowed(
+        1,
+        1,
+        teacher_map,
+        student_groups,
+        group_members,
+        group_subj_map,
+        block_map,
+        fixed_pairs,
+    )
+    assert not allowed
+    conn.close()
+


### PR DESCRIPTION
## Summary
- prevent blocking a teacher assigned to a student or required by that student's groups
- add helper `block_allowed` for block validation
- unit test for blocking a teacher with a fixed assignment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885c5b1e9e08322abb722d6ec2c51d1