### PR TITLE
Enable group suppression and batch teacher unavailability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 timetable.db
+.venv/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A local-first, browser-based school timetabling application built with **Python 
 ## 💡 Key Features
 
 - Configure teachers, students, subjects and groups through a web form
-- Mark teachers unavailable in specific slots or assign fixed lessons
+- Mark teachers unavailable in specific slots or assign fixed lessons, with batch selection for multiple teachers and slots
 - Specify teachers that individual students should avoid
 - Generate optimized timetables using OR-Tools CP-SAT
 - Record and view attendance history for each student and subject
@@ -107,7 +107,9 @@ When using group lessons you can adjust **Group weight** to bias the solver
 toward scheduling them. This multiplier boosts the objective weight of any
 variable whose ``student_id`` represents a group, making joint lessons more
 appealing relative to individual ones. A value around **2** is a good
-starting point and roughly doubles the attractiveness of group lessons.
+starting point and roughly doubles the attractiveness of group lessons, while
+lower values reduce their priority. Setting the weight to **0** effectively
+suppresses group lessons entirely.
 
 You can also block specific student/teacher pairings. The configuration form
 lets you tick the teachers a student should avoid. The app checks each block

--- a/static/config.js
+++ b/static/config.js
@@ -21,17 +21,30 @@ document.addEventListener('DOMContentLoaded', function () {
         localStorage.setItem(ACC_KEY, JSON.stringify(open));
     }
 
-    const savedPanels = JSON.parse(localStorage.getItem(ACC_KEY) || '[]');
-    savedPanels.forEach(id => {
-        const panel = document.querySelector(id);
-        const btn = document.querySelector(`#config-accordion button[data-accordion-target="${id}"]`);
-        if (panel && btn) {
-            panel.classList.remove('hidden');
-            btn.setAttribute('aria-expanded', 'true');
-            const icon = btn.querySelector('[data-accordion-icon]');
-            if (icon) icon.classList.add('rotate-180');
-        }
-    });
+    const savedRaw = localStorage.getItem(ACC_KEY);
+    if (savedRaw) {
+        const savedPanels = JSON.parse(savedRaw);
+        accordionButtons.forEach(btn => {
+            const id = btn.getAttribute('data-accordion-target');
+            const panel = document.querySelector(id);
+            if (panel) {
+                panel.classList.add('hidden');
+                btn.setAttribute('aria-expanded', 'false');
+                const icon = btn.querySelector('[data-accordion-icon]');
+                if (icon) icon.classList.remove('rotate-180');
+            }
+        });
+        savedPanels.forEach(id => {
+            const panel = document.querySelector(id);
+            const btn = document.querySelector(`#config-accordion button[data-accordion-target="${id}"]`);
+            if (panel && btn) {
+                panel.classList.remove('hidden');
+                btn.setAttribute('aria-expanded', 'true');
+                const icon = btn.querySelector('[data-accordion-icon]');
+                if (icon) icon.classList.add('rotate-180');
+            }
+        });
+    }
 
     accordionButtons.forEach(btn => {
         btn.addEventListener('click', () => {

--- a/static/config.js
+++ b/static/config.js
@@ -8,6 +8,37 @@ document.addEventListener('DOMContentLoaded', function () {
     const subjectSelect = document.getElementById('new_assign_subject');
     const slotSelect = document.getElementById('new_assign_slot');
 
+    const accordionButtons = document.querySelectorAll('#config-accordion button[data-accordion-target]');
+    const ACC_KEY = 'config_open_panels';
+
+    function saveAccordionState() {
+        const open = Array.from(accordionButtons)
+            .map(btn => btn.getAttribute('data-accordion-target'))
+            .filter(id => {
+                const panel = document.querySelector(id);
+                return panel && !panel.classList.contains('hidden');
+            });
+        localStorage.setItem(ACC_KEY, JSON.stringify(open));
+    }
+
+    const savedPanels = JSON.parse(localStorage.getItem(ACC_KEY) || '[]');
+    savedPanels.forEach(id => {
+        const panel = document.querySelector(id);
+        const btn = document.querySelector(`#config-accordion button[data-accordion-target="${id}"]`);
+        if (panel && btn) {
+            panel.classList.remove('hidden');
+            btn.setAttribute('aria-expanded', 'true');
+            const icon = btn.querySelector('[data-accordion-icon]');
+            if (icon) icon.classList.add('rotate-180');
+        }
+    });
+
+    accordionButtons.forEach(btn => {
+        btn.addEventListener('click', () => {
+            setTimeout(saveAccordionState, 0);
+        });
+    });
+
     const slotTimesDataEl = document.getElementById('slot-times-data');
     const slotTimesContainer = document.getElementById('slot-times');
     const slotsInput = document.querySelector('input[name="slots_per_day"]');
@@ -127,30 +158,36 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const unavailTeacher = document.getElementById('new_unavail_teacher');
     const unavailSlot = document.getElementById('new_unavail_slot');
-    // Display a warning when marking a slot unavailable would conflict.
+    // Display a warning when marking slots unavailable would conflict.
     function warnUnavail() {
-        const tid = unavailTeacher.value;
-        const slotVal = unavailSlot.value;
-        const slot = parseInt(slotVal, 10) - 1;
-        if (!tid || isNaN(slot)) return;
-        const fixed = assignData[tid] || [];
-        const unav = unavailData[tid] || [];
+        if (!unavailTeacher || !unavailSlot) return;
+        const tids = Array.from(unavailTeacher.selectedOptions).map(o => o.value);
+        const slots = Array.from(unavailSlot.selectedOptions).map(o => parseInt(o.value, 10) - 1);
+        if (!tids.length || !slots.length) return;
         const flashes = document.getElementById('flash-messages');
         if (!flashes) return;
-        const li = document.createElement('li');
-        li.className = 'error';
-        if (fixed.includes(slot)) {
-            li.textContent = 'Warning: fixed assignment exists in this slot.';
-        } else if (unav.includes(slot)) {
-            li.textContent = 'Slot already marked unavailable.';
-        } else {
-            return;
-        }
-        flashes.appendChild(li);
+        tids.forEach(tid => {
+            const fixed = assignData[tid] || [];
+            const unav = unavailData[tid] || [];
+            slots.forEach(slot => {
+                let msg = '';
+                if (fixed.includes(slot)) {
+                    msg = 'Warning: fixed assignment exists in this slot.';
+                } else if (unav.includes(slot)) {
+                    msg = 'Slot already marked unavailable.';
+                }
+                if (msg) {
+                    const li = document.createElement('li');
+                    li.className = 'error';
+                    li.textContent = msg;
+                    flashes.appendChild(li);
+                }
+            });
+        });
     }
     if (unavailTeacher && unavailSlot) {
         unavailTeacher.addEventListener('change', warnUnavail);
-        unavailSlot.addEventListener('input', warnUnavail);
+        unavailSlot.addEventListener('change', warnUnavail);
     }
 
     

--- a/templates/config.html
+++ b/templates/config.html
@@ -106,7 +106,7 @@
                 <input type="number" name="well_attend_weight" value="{{ config['well_attend_weight'] }}" min="0" step="0.1" class="border border-emerald-300 rounded-lg p-2.5 w-full">
             </label>
             <label class="block">Group weight:
-                <input type="number" name="group_weight" value="{{ config['group_weight'] }}" min="1" step="0.1" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                <input type="number" name="group_weight" value="{{ config['group_weight'] }}" min="0" step="0.1" class="border border-emerald-300 rounded-lg p-2.5 w-full">
             </label>
             <label class="flex items-center gap-2">Balance teacher load?
                 <input type="checkbox" name="balance_teacher_load" {% if config['balance_teacher_load'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
@@ -330,15 +330,19 @@
                 <input type="checkbox" name="unavail_delete" value="{{ u['id'] }}" class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
             </label>
             {% endfor %}
-            <label class="block">Teacher:
-                <select name="new_unavail_teacher" id="new_unavail_teacher" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+            <label class="block">Teachers:
+                <select multiple name="new_unavail_teacher" id="new_unavail_teacher" class="border border-emerald-300 rounded-lg p-2.5 w-full">
                     {% for t in teachers %}
                     <option value="{{ t['id'] }}">{{ t['name'] }}</option>
                     {% endfor %}
                 </select>
             </label>
-            <label class="block">Slot:
-                <input type="number" name="new_unavail_slot" id="new_unavail_slot" min="1" max="{{ config['slots_per_day'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+            <label class="block">Slots:
+                <select multiple name="new_unavail_slot" id="new_unavail_slot" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                    {% for i in range(1, config['slots_per_day'] + 1) %}
+                    <option value="{{ i }}">{{ i }}</option>
+                    {% endfor %}
+                </select>
             </label>
         </fieldset>
     </div>

--- a/tests/test_batch_unavailability.py
+++ b/tests/test_batch_unavailability.py
@@ -1,0 +1,36 @@
+import os
+import sys
+from werkzeug.datastructures import MultiDict
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+
+def setup_db(tmp_path):
+    import app, sqlite3
+    app.DB_PATH = str(tmp_path / 'test.db')
+    app.init_db()
+    conn = sqlite3.connect(app.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def test_batch_teacher_unavailability(tmp_path):
+    import app
+    conn = setup_db(tmp_path)
+    slot_starts = {f'slot_start_{i}': f'08:{30 + (i-1)*30:02d}' for i in range(1,9)}
+    data_items = [
+        ('slots_per_day', '8'), ('slot_duration', '30'),
+        ('min_lessons', '1'), ('max_lessons', '4'),
+        ('teacher_min_lessons', '1'), ('teacher_max_lessons', '8'),
+        ('max_repeats', '2'), ('consecutive_weight', '3'),
+        ('attendance_weight', '10'), ('well_attend_weight', '1'),
+        ('group_weight', '2.0'), ('balance_weight', '1'),
+        ('new_unavail_teacher', '1'), ('new_unavail_teacher', '2'),
+        ('new_unavail_slot', '1'), ('new_unavail_slot', '2'),
+    ] + list(slot_starts.items())
+    data = MultiDict(data_items)
+    with app.app.test_request_context('/config', method='POST', data=data):
+        app.config()
+    rows = conn.execute('SELECT teacher_id, slot FROM teacher_unavailable').fetchall()
+    conn.close()
+    assert {(r['teacher_id'], r['slot']) for r in rows} == {(1,0),(1,1),(2,0),(2,1)}

--- a/tests/test_fixed_assignment_groups.py
+++ b/tests/test_fixed_assignment_groups.py
@@ -49,3 +49,37 @@ def test_group_fixed_assignment_priority(tmp_path):
     assert row['teacher_id'] == 1
     assert row['subject'] == 'Math'
     assert row['slot'] == 0
+
+
+def test_group_fixed_assignment_suppressed(tmp_path):
+    import app, json
+    conn = setup_db(tmp_path)
+    c = conn.cursor()
+    c.execute("INSERT INTO groups (name, subjects) VALUES ('Group A', ?)", (json.dumps(['Math']),))
+    c.execute("INSERT INTO groups (name, subjects) VALUES ('Group B', ?)", (json.dumps(['Math']),))
+    c.execute("INSERT INTO group_members (group_id, student_id) VALUES (1,1)")
+    c.execute("INSERT INTO group_members (group_id, student_id) VALUES (2,2)")
+    conn.commit()
+
+    slot_starts = {f'slot_start_{i}': f'08:{30 + (i-1)*30:02d}' for i in range(1,9)}
+    data = {
+        'slots_per_day':'8', 'slot_duration':'30',
+        'min_lessons':'1', 'max_lessons':'4',
+        'teacher_min_lessons':'1', 'teacher_max_lessons':'8',
+        'max_repeats':'2', 'consecutive_weight':'3',
+        'attendance_weight':'10', 'well_attend_weight':'1',
+        'group_weight':'0', 'balance_weight':'1',
+        'new_assign_teacher':'1', 'new_assign_group':'2',
+        'new_assign_student':'1', 'new_assign_subject':'Math',
+        'new_assign_slot':'1', **slot_starts,
+    }
+    with app.app.test_request_context('/config', method='POST', data=data):
+        app.config()
+
+    row = conn.execute('SELECT teacher_id, student_id, group_id, subject, slot FROM fixed_assignments').fetchone()
+    conn.close()
+    assert row['group_id'] is None
+    assert row['student_id'] == 1
+    assert row['teacher_id'] == 1
+    assert row['subject'] == 'Math'
+    assert row['slot'] == 0

--- a/tests/test_persist_deleted_entries.py
+++ b/tests/test_persist_deleted_entries.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import sqlite3
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+
+def setup_db(tmp_path):
+    import app
+    app.DB_PATH = str(tmp_path / 'test.db')
+    app.init_db()
+    conn = sqlite3.connect(app.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def test_deleted_records_not_recreated(tmp_path):
+    import app
+    conn = setup_db(tmp_path)
+    conn.execute('DELETE FROM teachers')
+    conn.execute('DELETE FROM students')
+    conn.commit()
+    conn.close()
+
+    # simulate application restart
+    app.init_db()
+
+    conn = sqlite3.connect(app.DB_PATH)
+    cur = conn.cursor()
+    teacher_count = cur.execute('SELECT COUNT(*) FROM teachers').fetchone()[0]
+    student_count = cur.execute('SELECT COUNT(*) FROM students').fetchone()[0]
+    conn.close()
+
+    assert teacher_count == 0
+    assert student_count == 0


### PR DESCRIPTION
## Summary
- Allow group weight to be set to zero, making student fixed assignments take precedence when a group is also chosen
- Support selecting multiple teachers and slots to block availability in one submission
- Keep configuration accordions open after saving so reloaded pages preserve the last expanded sections
- Document and test the new behaviours

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b54b7358c083229e73508c953ffb2c