### PR TITLE
Add per-student advanced configuration options

### DIFF
--- a/app.py
+++ b/app.py
@@ -127,10 +127,29 @@ def init_db():
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             name TEXT UNIQUE,
             subjects TEXT,
-            active INTEGER DEFAULT 1
+            active INTEGER DEFAULT 1,
+            min_lessons INTEGER,
+            max_lessons INTEGER,
+            allow_repeats INTEGER,
+            max_repeats INTEGER,
+            allow_consecutive INTEGER,
+            prefer_consecutive INTEGER
         )''')
-    elif not column_exists('students', 'active'):
-        c.execute('ALTER TABLE students ADD COLUMN active INTEGER DEFAULT 1')
+    else:
+        if not column_exists('students', 'active'):
+            c.execute('ALTER TABLE students ADD COLUMN active INTEGER DEFAULT 1')
+        if not column_exists('students', 'min_lessons'):
+            c.execute('ALTER TABLE students ADD COLUMN min_lessons INTEGER')
+        if not column_exists('students', 'max_lessons'):
+            c.execute('ALTER TABLE students ADD COLUMN max_lessons INTEGER')
+        if not column_exists('students', 'allow_repeats'):
+            c.execute('ALTER TABLE students ADD COLUMN allow_repeats INTEGER')
+        if not column_exists('students', 'max_repeats'):
+            c.execute('ALTER TABLE students ADD COLUMN max_repeats INTEGER')
+        if not column_exists('students', 'allow_consecutive'):
+            c.execute('ALTER TABLE students ADD COLUMN allow_consecutive INTEGER')
+        if not column_exists('students', 'prefer_consecutive'):
+            c.execute('ALTER TABLE students ADD COLUMN prefer_consecutive INTEGER')
 
     if not table_exists('students_archive'):
         c.execute('''CREATE TABLE students_archive (
@@ -152,6 +171,13 @@ def init_db():
         c.execute('''CREATE TABLE teacher_unavailable (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             teacher_id INTEGER,
+            slot INTEGER
+        )''')
+
+    if not table_exists('student_unavailable'):
+        c.execute('''CREATE TABLE student_unavailable (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            student_id INTEGER,
             slot INTEGER
         )''')
 
@@ -537,9 +563,28 @@ def config():
                 name = request.form.get(f'student_name_{sid}')
                 subs = request.form.getlist(f'student_subjects_{sid}')
                 active = 1 if request.form.get(f'student_active_{sid}') else 0
+                smin = request.form.get(f'student_min_{sid}')
+                smax = request.form.get(f'student_max_{sid}')
+                allow_rep = 1 if request.form.get(f'student_allow_repeats_{sid}') else 0
+                max_rep = request.form.get(f'student_max_repeats_{sid}')
+                allow_con = 1 if request.form.get(f'student_allow_consecutive_{sid}') else 0
+                prefer_con = 1 if request.form.get(f'student_prefer_consecutive_{sid}') else 0
                 subj_json = json.dumps(subs)
-                c.execute('UPDATE students SET name=?, subjects=?, active=? WHERE id=?',
-                          (name, subj_json, active, int(sid)))
+                min_val = int(smin) if smin else None
+                max_val = int(smax) if smax else None
+                max_rep_val = int(max_rep) if max_rep else None
+                c.execute('''UPDATE students SET name=?, subjects=?, active=?,
+                             min_lessons=?, max_lessons=?, allow_repeats=?,
+                             max_repeats=?, allow_consecutive=?, prefer_consecutive=?
+                             WHERE id=?''',
+                          (name, subj_json, active, min_val, max_val,
+                           allow_rep, max_rep_val, allow_con, prefer_con,
+                           int(sid)))
+                slots = request.form.getlist(f'student_unavail_{sid}')
+                c.execute('DELETE FROM student_unavailable WHERE student_id=?', (int(sid),))
+                for sl in slots:
+                    c.execute('INSERT INTO student_unavailable (student_id, slot) VALUES (?, ?)',
+                              (int(sid), int(sl)))
                 blocks = request.form.getlist(f'student_block_{sid}')
                 c.execute('DELETE FROM student_teacher_block WHERE student_id=?', (int(sid),))
                 block_map_current[int(sid)] = set()
@@ -557,11 +602,27 @@ def config():
         new_sname = request.form.get('new_student_name')
         new_ssubs = request.form.getlist('new_student_subjects')
         new_blocks = request.form.getlist('new_student_block')
+        new_unav = request.form.getlist('new_student_unavail')
+        new_smin = request.form.get('new_student_min')
+        new_smax = request.form.get('new_student_max')
+        new_allow_rep = 1 if request.form.get('new_student_allow_repeats') else 0
+        new_max_rep = request.form.get('new_student_max_repeats')
+        new_allow_con = 1 if request.form.get('new_student_allow_consecutive') else 0
+        new_prefer_con = 1 if request.form.get('new_student_prefer_consecutive') else 0
         if new_sname and new_ssubs:
             subj_json = json.dumps(new_ssubs)
-            c.execute('INSERT INTO students (name, subjects, active) VALUES (?, ?, 1)',
-                      (new_sname, subj_json))
+            min_val = int(new_smin) if new_smin else None
+            max_val = int(new_smax) if new_smax else None
+            max_rep_val = int(new_max_rep) if new_max_rep else None
+            c.execute('''INSERT INTO students (name, subjects, active, min_lessons, max_lessons,
+                      allow_repeats, max_repeats, allow_consecutive, prefer_consecutive)
+                      VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?)''',
+                      (new_sname, subj_json, min_val, max_val, new_allow_rep,
+                       max_rep_val, new_allow_con, new_prefer_con))
             new_sid = c.lastrowid
+            for sl in new_unav:
+                c.execute('INSERT INTO student_unavailable (student_id, slot) VALUES (?, ?)',
+                          (new_sid, int(sl)))
             block_map_current[new_sid] = set()
             for tid in new_blocks:
                 tval = int(tid)
@@ -788,6 +849,11 @@ def config():
     block_map = {}
     for r in st_rows:
         block_map.setdefault(r['student_id'], []).append(r['teacher_id'])
+    c.execute('SELECT student_id, slot FROM student_unavailable')
+    su_rows = c.fetchall()
+    student_unavail_map = {}
+    for r in su_rows:
+        student_unavail_map.setdefault(r['student_id'], []).append(r['slot'])
     c.execute('SELECT * FROM subjects')
     subjects = c.fetchall()
     c.execute('SELECT * FROM groups')
@@ -827,7 +893,8 @@ def config():
                            unavail_map=unavail_map, assign_map=assign_map,
                            group_map=group_map, group_subj_map=group_subj_map,
                            block_map=block_map, json=json,
-                           slot_times=slot_times)
+                           slot_times=slot_times,
+                           student_unavail_map=student_unavail_map)
 
 
 def generate_schedule(target_date=None):
@@ -887,6 +954,11 @@ def generate_schedule(target_date=None):
             union.update(block_map_sched.get(m, set()))
         if union:
             block_map_sched[offset + gid] = union
+    c.execute('SELECT student_id, slot FROM student_unavailable')
+    su_rows = c.fetchall()
+    student_unavailable = {}
+    for r in su_rows:
+        student_unavailable.setdefault(r['student_id'], set()).add(r['slot'])
     c.execute('SELECT * FROM fixed_assignments')
     arows = c.fetchall()
     assignments_fixed = []
@@ -915,6 +987,19 @@ def generate_schedule(target_date=None):
     allow_multi_teacher = bool(cfg['allow_multi_teacher'])
     balance_teacher_load = bool(cfg['balance_teacher_load'])
     balance_weight = cfg['balance_weight']
+    student_limits = {}
+    student_repeat = {}
+    for s in students:
+        sid = s['id']
+        student_limits[sid] = (
+            s['min_lessons'] if s['min_lessons'] is not None else min_lessons,
+            s['max_lessons'] if s['max_lessons'] is not None else max_lessons)
+        student_repeat[sid] = {
+            'allow_repeats': bool(s['allow_repeats']) if s['allow_repeats'] is not None else allow_repeats,
+            'max_repeats': s['max_repeats'] if s['max_repeats'] is not None else max_repeats,
+            'allow_consecutive': bool(s['allow_consecutive']) if s['allow_consecutive'] is not None else allow_consecutive,
+            'prefer_consecutive': bool(s['prefer_consecutive']) if s['prefer_consecutive'] is not None else prefer_consecutive,
+        }
     # Build the CP-SAT model with assumption literals so that we can obtain
     # an unsat core explaining conflicts when no timetable exists.
     # incorporate groups as pseudo students
@@ -975,7 +1060,10 @@ def generate_schedule(target_date=None):
         allow_multi_teacher=allow_multi_teacher,
         balance_teacher_load=balance_teacher_load,
         balance_weight=balance_weight,
-        blocked=block_map_sched)
+        blocked=block_map_sched,
+        student_limits=student_limits,
+        student_repeat=student_repeat,
+        student_unavailable=student_unavailable)
     status, assignments, core = solve_and_print(model, vars_, assumptions)
 
     # Insert solver results into DB

--- a/cp_sat_timetable.py
+++ b/cp_sat_timetable.py
@@ -16,7 +16,8 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
                 require_all_subjects=True, subject_weights=None,
                 group_weight=1.0, allow_multi_teacher=True,
                 balance_teacher_load=False, balance_weight=1,
-                blocked=None):
+                blocked=None, student_limits=None,
+                student_repeat=None, student_unavailable=None):
     """Build CP-SAT model for the scheduling problem.
 
     When ``add_assumptions`` is ``True``, Boolean indicators are created for the
@@ -60,6 +61,13 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
             teachers that cannot teach the given student. When group ids are
             included in the mapping, those restrictions apply to the entire
             group.
+        student_limits: optional mapping ``student_id -> (min, max)`` to override
+            the global student lesson limits.
+        student_repeat: optional mapping ``student_id -> dict`` specifying
+            repeat preferences (``allow_repeats``, ``max_repeats``,
+            ``allow_consecutive`` and ``prefer_consecutive``).
+        student_unavailable: optional mapping ``student_id -> set(slots)`` of
+            time slots where the student cannot attend lessons.
 
     Returns:
         model (cp_model.CpModel): The constructed model.
@@ -121,6 +129,9 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
     # is scheduled exclusively through the group so individual variables are not
     # created.
     blocked = blocked or {}
+    student_limits = student_limits or {}
+    student_repeat = student_repeat or {}
+    student_unavailable = student_unavailable or {}
     for student in students:
         student_subs = set(json.loads(student['subjects']))
         forbidden = set(blocked.get(student['id'], []))
@@ -132,6 +143,8 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
                         subject in member_group_subjects.get(student['id'], set())):
                     continue
                 for slot in range(slots):
+                    if slot in student_unavailable.get(student['id'], set()):
+                        continue
                     key = (student['id'], teacher['id'], subject, slot)
                     if (not add_assumptions and key not in fixed_set and
                             ((teacher['id'], slot) in unavailable_set or
@@ -178,6 +191,7 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
         sid = student['id']
         if sid in group_ids:
             continue
+        blocked_slots = student_unavailable.get(sid, set())
         for slot in range(slots):
             possible = [var for (s, t, subj, sl), var in vars_.items()
                         if s == sid and sl == slot]
@@ -185,7 +199,12 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
                 if g_key[3] == slot:  # slot matches
                     possible.append(g_var)
             if possible:
-                model.Add(sum(possible) <= 1)
+                if slot in blocked_slots:
+                    ct = model.Add(sum(possible) == 0)
+                    if add_assumptions:
+                        ct.OnlyEnforceIf(assumptions['student_limits'])
+                else:
+                    model.Add(sum(possible) <= 1)
 
     # Constraint 3: limit repeats of the same student/teacher/subject combination.  Group
     # lessons are treated the same way as individual lessons and therefore their
@@ -198,19 +217,24 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
     # consecutive repeat lessons.  ``repeat_limit`` is set to 1 when repeats are
     # disallowed.
     adjacency_vars = []
-    repeat_limit = max_repeats if allow_repeats else 1
     for (sid, tid, subj), slot_map in triple_map.items():
+        cfg = student_repeat.get(sid, {})
+        allow_rep = cfg.get('allow_repeats', allow_repeats)
+        max_rep = cfg.get('max_repeats', max_repeats)
+        allow_consec_s = cfg.get('allow_consecutive', allow_consecutive)
+        prefer_consec_s = cfg.get('prefer_consecutive', prefer_consecutive)
+        repeat_limit = max_rep if allow_rep else 1
         vars_list = list(slot_map.values())
         ct = model.Add(sum(vars_list) <= repeat_limit)
         if add_assumptions:
             ct.OnlyEnforceIf(assumptions['repeat_restrictions'])
-        if not allow_consecutive and repeat_limit > 1:
+        if not allow_consec_s and repeat_limit > 1:
             for s in range(slots - 1):
                 if s in slot_map and s + 1 in slot_map:
                     ct2 = model.Add(slot_map[s] + slot_map[s + 1] <= 1)
                     if add_assumptions:
                         ct2.OnlyEnforceIf(assumptions['repeat_restrictions'])
-        if prefer_consecutive and allow_consecutive and repeat_limit > 1:
+        if prefer_consec_s and allow_consec_s and repeat_limit > 1:
             for s in range(slots - 1):
                 if s in slot_map and s + 1 in slot_map:
                     v1 = slot_map[s]
@@ -289,8 +313,9 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
             total_set.add(g_var)
         total = list(total_set)
         if total:
-            ct_min = model.Add(sum(total) >= min_lessons)
-            ct_max = model.Add(sum(total) <= max_lessons)
+            min_l, max_l = student_limits.get(sid, (min_lessons, max_lessons))
+            ct_min = model.Add(sum(total) >= min_l)
+            ct_max = model.Add(sum(total) <= max_l)
             if add_assumptions:
                 ct_min.OnlyEnforceIf(assumptions['student_limits'])
                 ct_max.OnlyEnforceIf(assumptions['student_limits'])
@@ -300,7 +325,7 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
     # depending on the configuration options.
     weighted_sum = sum(var * var_weights.get(var, 1) for var in vars_.values())
     objective = weighted_sum
-    if prefer_consecutive and allow_consecutive and repeat_limit > 1 and adjacency_vars:
+    if adjacency_vars:
         objective += consecutive_weight * sum(adjacency_vars)
     if balance_teacher_load and teacher_load_vars:
         objective -= balance_weight * load_diff

--- a/templates/config.html
+++ b/templates/config.html
@@ -234,6 +234,38 @@
                     {% endfor %}
                 </select>
             </label>
+            <button type="button" onclick="document.getElementById('adv-{{ s['id'] }}').showModal()" class="bg-emerald-200 text-emerald-800 px-2 py-1 rounded">Advanced</button>
+            <dialog id="adv-{{ s['id'] }}" class="p-4 rounded">
+                <h3 class="text-lg mb-2">Advanced settings for {{ s['name'] }}</h3>
+                <label class="block">Blocked Slots:
+                    <select multiple name="student_unavail_{{ s['id'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                        {% for i in range(config['slots_per_day']) %}
+                        <option value="{{ i }}" {% if i in student_unavail_map.get(s['id'], []) %}selected{% endif %}>Slot {{ i + 1 }}</option>
+                        {% endfor %}
+                    </select>
+                </label>
+                <label class="block">Min lessons:
+                    <input type="number" name="student_min_{{ s['id'] }}" value="{{ s['min_lessons'] if s['min_lessons'] is not none else config['min_lessons'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                </label>
+                <label class="block">Max lessons:
+                    <input type="number" name="student_max_{{ s['id'] }}" value="{{ s['max_lessons'] if s['max_lessons'] is not none else config['max_lessons'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                </label>
+                <label class="flex items-center gap-2">Allow repeated lessons?
+                    <input type="checkbox" name="student_allow_repeats_{{ s['id'] }}" {% if (s['allow_repeats'] if s['allow_repeats'] is not none else config['allow_repeats']) %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                </label>
+                <label class="block">Max repeats:
+                    <input type="number" name="student_max_repeats_{{ s['id'] }}" value="{{ s['max_repeats'] if s['max_repeats'] is not none else config['max_repeats'] }}" min="1" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                </label>
+                <label class="flex items-center gap-2">Allow consecutive repeats?
+                    <input type="checkbox" name="student_allow_consecutive_{{ s['id'] }}" {% if (s['allow_consecutive'] if s['allow_consecutive'] is not none else config['allow_consecutive']) %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                </label>
+                <label class="flex items-center gap-2">Prefer consecutive repeats?
+                    <input type="checkbox" name="student_prefer_consecutive_{{ s['id'] }}" {% if (s['prefer_consecutive'] if s['prefer_consecutive'] is not none else config['prefer_consecutive']) %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                </label>
+                <div class="mt-2 text-right">
+                    <button type="button" onclick="document.getElementById('adv-{{ s['id'] }}').close()" class="bg-emerald-500 text-white px-3 py-1 rounded">Close</button>
+                </div>
+            </dialog>
             <label class="flex items-center gap-2">Delete?
                 <input type="checkbox" name="student_delete_{{ s['id'] }}" value="1" class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
             </label>
@@ -255,6 +287,38 @@
                     {% endfor %}
                 </select>
             </label>
+            <button type="button" onclick="document.getElementById('adv-new').showModal()" class="bg-emerald-200 text-emerald-800 px-2 py-1 rounded">Advanced</button>
+            <dialog id="adv-new" class="p-4 rounded">
+                <h3 class="text-lg mb-2">Advanced settings for new student</h3>
+                <label class="block">Blocked Slots:
+                    <select multiple name="new_student_unavail" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                        {% for i in range(config['slots_per_day']) %}
+                        <option value="{{ i }}">Slot {{ i + 1 }}</option>
+                        {% endfor %}
+                    </select>
+                </label>
+                <label class="block">Min lessons:
+                    <input type="number" name="new_student_min" value="{{ config['min_lessons'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                </label>
+                <label class="block">Max lessons:
+                    <input type="number" name="new_student_max" value="{{ config['max_lessons'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                </label>
+                <label class="flex items-center gap-2">Allow repeated lessons?
+                    <input type="checkbox" name="new_student_allow_repeats" {% if config['allow_repeats'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                </label>
+                <label class="block">Max repeats:
+                    <input type="number" name="new_student_max_repeats" value="{{ config['max_repeats'] }}" min="1" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                </label>
+                <label class="flex items-center gap-2">Allow consecutive repeats?
+                    <input type="checkbox" name="new_student_allow_consecutive" {% if config['allow_consecutive'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                </label>
+                <label class="flex items-center gap-2">Prefer consecutive repeats?
+                    <input type="checkbox" name="new_student_prefer_consecutive" {% if config['prefer_consecutive'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                </label>
+                <div class="mt-2 text-right">
+                    <button type="button" onclick="document.getElementById('adv-new').close()" class="bg-emerald-500 text-white px-3 py-1 rounded">Close</button>
+                </div>
+            </dialog>
         </fieldset>
     </div>
     <!-- Groups -->

--- a/templates/config.html
+++ b/templates/config.html
@@ -234,38 +234,47 @@
                     {% endfor %}
                 </select>
             </label>
-            <button type="button" onclick="document.getElementById('adv-{{ s['id'] }}').showModal()" class="bg-emerald-200 text-emerald-800 px-2 py-1 rounded">Advanced</button>
-            <dialog id="adv-{{ s['id'] }}" class="p-4 rounded">
-                <h3 class="text-lg mb-2">Advanced settings for {{ s['name'] }}</h3>
-                <label class="block">Blocked Slots:
-                    <select multiple name="student_unavail_{{ s['id'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
-                        {% for i in range(config['slots_per_day']) %}
-                        <option value="{{ i }}" {% if i in student_unavail_map.get(s['id'], []) %}selected{% endif %}>Slot {{ i + 1 }}</option>
-                        {% endfor %}
-                    </select>
-                </label>
-                <label class="block">Min lessons:
-                    <input type="number" name="student_min_{{ s['id'] }}" value="{{ s['min_lessons'] if s['min_lessons'] is not none else config['min_lessons'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
-                </label>
-                <label class="block">Max lessons:
-                    <input type="number" name="student_max_{{ s['id'] }}" value="{{ s['max_lessons'] if s['max_lessons'] is not none else config['max_lessons'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
-                </label>
-                <label class="flex items-center gap-2">Allow repeated lessons?
-                    <input type="checkbox" name="student_allow_repeats_{{ s['id'] }}" {% if (s['allow_repeats'] if s['allow_repeats'] is not none else config['allow_repeats']) %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
-                </label>
-                <label class="block">Max repeats:
-                    <input type="number" name="student_max_repeats_{{ s['id'] }}" value="{{ s['max_repeats'] if s['max_repeats'] is not none else config['max_repeats'] }}" min="1" class="border border-emerald-300 rounded-lg p-2.5 w-full">
-                </label>
-                <label class="flex items-center gap-2">Allow consecutive repeats?
-                    <input type="checkbox" name="student_allow_consecutive_{{ s['id'] }}" {% if (s['allow_consecutive'] if s['allow_consecutive'] is not none else config['allow_consecutive']) %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
-                </label>
-                <label class="flex items-center gap-2">Prefer consecutive repeats?
-                    <input type="checkbox" name="student_prefer_consecutive_{{ s['id'] }}" {% if (s['prefer_consecutive'] if s['prefer_consecutive'] is not none else config['prefer_consecutive']) %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
-                </label>
-                <div class="mt-2 text-right">
-                    <button type="button" onclick="document.getElementById('adv-{{ s['id'] }}').close()" class="bg-emerald-500 text-white px-3 py-1 rounded">Close</button>
+            <button type="button" data-modal-target="adv-{{ s['id'] }}" data-modal-toggle="adv-{{ s['id'] }}" class="bg-emerald-200 text-emerald-800 px-2 py-1 rounded">Advanced</button>
+            <div id="adv-{{ s['id'] }}" tabindex="-1" aria-hidden="true" class="hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-[calc(100%-1rem)] max-h-full">
+                <div class="relative p-4 w-full max-w-md max-h-full">
+                    <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
+                        <div class="p-4">
+                            <h3 class="text-lg mb-2">Advanced settings for {{ s['name'] }}</h3>
+                            <label class="block">Blocked Slots:
+                                <select multiple name="student_unavail_{{ s['id'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                                    {% for i in range(config['slots_per_day']) %}
+                                    <option value="{{ i }}" {% if i in student_unavail_map.get(s['id'], []) %}selected{% endif %}>Slot {{ i + 1 }}</option>
+                                    {% endfor %}
+                                </select>
+                            </label>
+                            <label class="block">Min lessons:
+                                <input type="number" name="student_min_{{ s['id'] }}" value="{{ s['min_lessons'] if s['min_lessons'] is not none else config['min_lessons'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                            </label>
+                            <label class="block">Max lessons:
+                                <input type="number" name="student_max_{{ s['id'] }}" value="{{ s['max_lessons'] if s['max_lessons'] is not none else config['max_lessons'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                            </label>
+                            <label class="flex items-center gap-2">Allow repeated lessons?
+                                <input type="checkbox" name="student_allow_repeats_{{ s['id'] }}" {% if (s['allow_repeats'] if s['allow_repeats'] is not none else config['allow_repeats']) %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                            </label>
+                            <label class="flex items-center gap-2">Allow different teachers per subject?
+                                <input type="checkbox" name="student_multi_teacher_{{ s['id'] }}" {% if (s['allow_multi_teacher'] if s['allow_multi_teacher'] is not none else config['allow_multi_teacher']) %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                            </label>
+                            <label class="block">Max repeats:
+                                <input type="number" name="student_max_repeats_{{ s['id'] }}" value="{{ s['max_repeats'] if s['max_repeats'] is not none else config['max_repeats'] }}" min="1" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                            </label>
+                            <label class="flex items-center gap-2">Allow consecutive repeats?
+                                <input type="checkbox" name="student_allow_consecutive_{{ s['id'] }}" {% if (s['allow_consecutive'] if s['allow_consecutive'] is not none else config['allow_consecutive']) %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                            </label>
+                            <label class="flex items-center gap-2">Prefer consecutive repeats?
+                                <input type="checkbox" name="student_prefer_consecutive_{{ s['id'] }}" {% if (s['prefer_consecutive'] if s['prefer_consecutive'] is not none else config['prefer_consecutive']) %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                            </label>
+                            <div class="mt-2 text-right">
+                                <button type="button" data-modal-hide="adv-{{ s['id'] }}" class="bg-emerald-500 text-white px-3 py-1 rounded">Close</button>
+                            </div>
+                        </div>
+                    </div>
                 </div>
-            </dialog>
+            </div>
             <label class="flex items-center gap-2">Delete?
                 <input type="checkbox" name="student_delete_{{ s['id'] }}" value="1" class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
             </label>
@@ -287,38 +296,47 @@
                     {% endfor %}
                 </select>
             </label>
-            <button type="button" onclick="document.getElementById('adv-new').showModal()" class="bg-emerald-200 text-emerald-800 px-2 py-1 rounded">Advanced</button>
-            <dialog id="adv-new" class="p-4 rounded">
-                <h3 class="text-lg mb-2">Advanced settings for new student</h3>
-                <label class="block">Blocked Slots:
-                    <select multiple name="new_student_unavail" class="border border-emerald-300 rounded-lg p-2.5 w-full">
-                        {% for i in range(config['slots_per_day']) %}
-                        <option value="{{ i }}">Slot {{ i + 1 }}</option>
-                        {% endfor %}
-                    </select>
-                </label>
-                <label class="block">Min lessons:
-                    <input type="number" name="new_student_min" value="{{ config['min_lessons'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
-                </label>
-                <label class="block">Max lessons:
-                    <input type="number" name="new_student_max" value="{{ config['max_lessons'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
-                </label>
-                <label class="flex items-center gap-2">Allow repeated lessons?
-                    <input type="checkbox" name="new_student_allow_repeats" {% if config['allow_repeats'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
-                </label>
-                <label class="block">Max repeats:
-                    <input type="number" name="new_student_max_repeats" value="{{ config['max_repeats'] }}" min="1" class="border border-emerald-300 rounded-lg p-2.5 w-full">
-                </label>
-                <label class="flex items-center gap-2">Allow consecutive repeats?
-                    <input type="checkbox" name="new_student_allow_consecutive" {% if config['allow_consecutive'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
-                </label>
-                <label class="flex items-center gap-2">Prefer consecutive repeats?
-                    <input type="checkbox" name="new_student_prefer_consecutive" {% if config['prefer_consecutive'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
-                </label>
-                <div class="mt-2 text-right">
-                    <button type="button" onclick="document.getElementById('adv-new').close()" class="bg-emerald-500 text-white px-3 py-1 rounded">Close</button>
+            <button type="button" data-modal-target="adv-new" data-modal-toggle="adv-new" class="bg-emerald-200 text-emerald-800 px-2 py-1 rounded">Advanced</button>
+            <div id="adv-new" tabindex="-1" aria-hidden="true" class="hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-[calc(100%-1rem)] max-h-full">
+                <div class="relative p-4 w-full max-w-md max-h-full">
+                    <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
+                        <div class="p-4">
+                            <h3 class="text-lg mb-2">Advanced settings for new student</h3>
+                            <label class="block">Blocked Slots:
+                                <select multiple name="new_student_unavail" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                                    {% for i in range(config['slots_per_day']) %}
+                                    <option value="{{ i }}">Slot {{ i + 1 }}</option>
+                                    {% endfor %}
+                                </select>
+                            </label>
+                            <label class="block">Min lessons:
+                                <input type="number" name="new_student_min" value="{{ config['min_lessons'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                            </label>
+                            <label class="block">Max lessons:
+                                <input type="number" name="new_student_max" value="{{ config['max_lessons'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                            </label>
+                            <label class="flex items-center gap-2">Allow repeated lessons?
+                                <input type="checkbox" name="new_student_allow_repeats" {% if config['allow_repeats'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                            </label>
+                            <label class="flex items-center gap-2">Allow different teachers per subject?
+                                <input type="checkbox" name="new_student_multi_teacher" {% if config['allow_multi_teacher'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                            </label>
+                            <label class="block">Max repeats:
+                                <input type="number" name="new_student_max_repeats" value="{{ config['max_repeats'] }}" min="1" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                            </label>
+                            <label class="flex items-center gap-2">Allow consecutive repeats?
+                                <input type="checkbox" name="new_student_allow_consecutive" {% if config['allow_consecutive'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                            </label>
+                            <label class="flex items-center gap-2">Prefer consecutive repeats?
+                                <input type="checkbox" name="new_student_prefer_consecutive" {% if config['prefer_consecutive'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                            </label>
+                            <div class="mt-2 text-right">
+                                <button type="button" data-modal-hide="adv-new" class="bg-emerald-500 text-white px-3 py-1 rounded">Close</button>
+                            </div>
+                        </div>
+                    </div>
                 </div>
-            </dialog>
+            </div>
         </fieldset>
     </div>
     <!-- Groups -->


### PR DESCRIPTION
## Summary
- Support custom lesson limits and repeat preferences for each student
- Allow blocking individual time slots per student
- Expose per-student advanced options on the configuration page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5afe6dc4883229d0d060bccc6f4f3