### PR TITLE
Show lesson counts in unscheduled lists

### DIFF
--- a/templates/edit_timetable.html
+++ b/templates/edit_timetable.html
@@ -60,7 +60,7 @@
         <ul class="mb-6">
             {% for sid, subs in missing.items() %}
             <li class="mb-1">
-                <strong>{{ student_names[sid] }}:</strong>
+                <strong>{{ student_names[sid] }} ({{ lesson_counts.get(sid, 0) }}):</strong>
                 {% for item in subs %}
                 <form method="post" class="inline-block ml-4 worksheet-form">
                     <input type="hidden" name="action" value="worksheet">

--- a/templates/index.html
+++ b/templates/index.html
@@ -101,7 +101,7 @@
             <h3 class="text-lg font-medium mt-4">Unscheduled Subjects</h3>
             <ul class="list-disc list-inside">
                 {% for sid, subs in missing.items() %}
-                <li>{{ student_names[sid] }}:
+                <li>{{ student_names[sid] }} ({{ lesson_counts.get(sid, 0) }}):
                     {% for item in subs %}
                         {% if item.today %}
                         <span class="worksheet-assigned">{{ item.subject }} ({{ item.count }})</span>{% if not loop.last %}, {% endif %}

--- a/templates/timetable.html
+++ b/templates/timetable.html
@@ -38,7 +38,7 @@
     <h2>Unscheduled Subjects</h2>
     <ul>
         {% for sid, subs in missing.items() %}
-        <li>{{ student_names[sid] }}:
+        <li>{{ student_names[sid] }} ({{ lesson_counts.get(sid, 0) }}):
             {% for item in subs %}
                 {% if item.today %}
                 <span class="worksheet-assigned">{{ item.subject }} ({{ item.count }})</span>{% if not loop.last %}, {% endif %}

--- a/tests/test_unassigned_inactive.py
+++ b/tests/test_unassigned_inactive.py
@@ -24,7 +24,7 @@ def test_inactive_student_listed_in_missing(tmp_path):
     conn.commit()
     conn.close()
 
-    _, _, _, _, missing, _, _, _ = app.get_timetable_data('2024-01-01')
+    _, _, _, _, missing, _, _, _, _ = app.get_timetable_data('2024-01-01')
     assert sid in missing
     subjects = {item['subject'] for item in missing[sid]}
     assert subjects == {'Math', 'English'}
@@ -52,7 +52,7 @@ def test_worksheet_counts_separate_by_id(tmp_path):
     conn.commit()
     conn.close()
 
-    _, _, _, _, missing, _, _, _ = app.get_timetable_data('2024-01-03')
+    _, _, _, _, missing, _, _, _, _ = app.get_timetable_data('2024-01-03')
     assert sid_new in missing
     math = next(item for item in missing[sid_new] if item['subject'] == 'Math')
     assert math['count'] == 0


### PR DESCRIPTION
## Summary
- Track how many lessons each student has on a given date
- Display lesson totals next to student names in the Unassigned/Unscheduled sections of timetable views
- Adjust tests for updated timetable data signature

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5bb2224888322bc8995bbef4cf677