### PR TITLE
Enable editing timetable lessons with locations

### DIFF
--- a/app.py
+++ b/app.py
@@ -662,6 +662,9 @@ def config():
                 c.execute('INSERT INTO student_teacher_block (student_id, teacher_id) VALUES (?, ?)',
                           (new_sid, tval))
                 block_map_current.setdefault(new_sid, set()).add(tval)
+            for lid in request.form.getlist('new_student_locs'):
+                c.execute('INSERT INTO student_locations (student_id, location_id) VALUES (?, ?)',
+                          (new_sid, int(lid)))
 
         # Build helper maps used when validating group changes. These maps
         # describe which teachers can teach each subject, what subjects every
@@ -765,6 +768,9 @@ def config():
                 for sid in member_ids:
                     c.execute('INSERT INTO group_members (group_id, student_id) VALUES (?, ?)',
                               (gid, sid))
+                for lid in request.form.getlist('new_group_locs'):
+                    c.execute('INSERT INTO group_locations (group_id, location_id) VALUES (?, ?)',
+                              (gid, int(lid)))
 
         # update locations and restrictions
         loc_ids = request.form.getlist('location_id')
@@ -784,18 +790,22 @@ def config():
         c.execute('SELECT id FROM students')
         student_ids = [r['id'] for r in c.fetchall()]
         for sid in student_ids:
-            sel = [int(x) for x in request.form.getlist(f'student_locs_{sid}')]
-            c.execute('DELETE FROM student_locations WHERE student_id=?', (sid,))
-            for lid in sel:
-                c.execute('INSERT INTO student_locations (student_id, location_id) VALUES (?, ?)', (sid, lid))
+            key = f'student_locs_{sid}'
+            if key in request.form:
+                sel = [int(x) for x in request.form.getlist(key)]
+                c.execute('DELETE FROM student_locations WHERE student_id=?', (sid,))
+                for lid in sel:
+                    c.execute('INSERT INTO student_locations (student_id, location_id) VALUES (?, ?)', (sid, lid))
 
         c.execute('SELECT id FROM groups')
         group_ids = [r['id'] for r in c.fetchall()]
         for gid in group_ids:
-            sel = [int(x) for x in request.form.getlist(f'group_locs_{gid}')]
-            c.execute('DELETE FROM group_locations WHERE group_id=?', (gid,))
-            for lid in sel:
-                c.execute('INSERT INTO group_locations (group_id, location_id) VALUES (?, ?)', (gid, lid))
+            key = f'group_locs_{gid}'
+            if key in request.form:
+                sel = [int(x) for x in request.form.getlist(key)]
+                c.execute('DELETE FROM group_locations WHERE group_id=?', (gid,))
+                for lid in sel:
+                    c.execute('INSERT INTO group_locations (group_id, location_id) VALUES (?, ?)', (gid, lid))
 
         # update teacher unavailability
         unavail_ids = request.form.getlist('unavail_id')

--- a/static/main.js
+++ b/static/main.js
@@ -89,6 +89,36 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     });
 
+    const editButtons = document.querySelectorAll('.edit-lesson-btn');
+    const entryInput = document.getElementById('entry-id-input');
+    const editStudentSelect = document.getElementById('edit-student-group');
+    const editSubjectSelect = document.getElementById('edit-subject');
+    const editLocationSelect = document.getElementById('edit-location');
+    const editModalEl = document.getElementById('edit-modal');
+    let editModal = null;
+    if (editModalEl && typeof Modal !== 'undefined') {
+        editModal = new Modal(editModalEl);
+    }
+    editButtons.forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            if (entryInput) entryInput.value = btn.dataset.entry;
+            if (editStudentSelect) {
+                if (btn.dataset.student) {
+                    editStudentSelect.value = 's' + btn.dataset.student;
+                } else if (btn.dataset.group) {
+                    editStudentSelect.value = 'g' + btn.dataset.group;
+                }
+            }
+            if (editSubjectSelect && btn.dataset.subject) {
+                editSubjectSelect.value = btn.dataset.subject;
+            }
+            if (editLocationSelect) {
+                editLocationSelect.value = btn.dataset.location || '';
+            }
+            if (editModal) editModal.show();
+        });
+    });
+
     const worksheetForms = document.querySelectorAll('.worksheet-form');
     worksheetForms.forEach(function (form) {
         const cb = form.querySelector('input[type="checkbox"]');

--- a/templates/config.html
+++ b/templates/config.html
@@ -234,6 +234,13 @@
                     {% endfor %}
                 </select>
             </label>
+            <label class="block">Locations:
+                <select multiple name="student_locs_{{ s['id'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                    {% for loc in locations %}
+                    <option value="{{ loc['id'] }}" {% if loc['id'] in student_loc_map.get(s['id'], []) %}selected{% endif %}>{{ loc['name'] }}</option>
+                    {% endfor %}
+                </select>
+            </label>
             <button type="button" data-modal-target="adv-{{ s['id'] }}" data-modal-toggle="adv-{{ s['id'] }}" class="bg-emerald-200 text-emerald-800 px-2 py-1 rounded">Advanced</button>
             <div id="adv-{{ s['id'] }}" tabindex="-1" aria-hidden="true" class="hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-[calc(100%-1rem)] max-h-full">
                 <div class="relative p-4 w-full max-w-md max-h-full">
@@ -293,6 +300,13 @@
                 <select multiple name="new_student_block" class="border border-emerald-300 rounded-lg p-2.5 w-full">
                     {% for t in teachers %}
                     <option value="{{ t['id'] }}">{{ t['name'] }}</option>
+                    {% endfor %}
+                </select>
+            </label>
+            <label class="block">Locations:
+                <select multiple name="new_student_locs" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                    {% for loc in locations %}
+                    <option value="{{ loc['id'] }}">{{ loc['name'] }}</option>
                     {% endfor %}
                 </select>
             </label>
@@ -370,6 +384,13 @@
                     {% endfor %}
                 </select>
             </label>
+            <label class="block">Locations:
+                <select multiple name="group_locs_{{ g['id'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                    {% for loc in locations %}
+                    <option value="{{ loc['id'] }}" {% if loc['id'] in group_loc_map.get(g['id'], []) %}selected{% endif %}>{{ loc['name'] }}</option>
+                    {% endfor %}
+                </select>
+            </label>
             <label class="flex items-center gap-2">Delete?
                 <input type="checkbox" name="group_delete" value="{{ g['id'] }}" class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
             </label>
@@ -388,6 +409,13 @@
                 <select multiple name="new_group_members" class="border border-emerald-300 rounded-lg p-2.5 w-full">
                     {% for s in students %}
                     <option value="{{ s['id'] }}">{{ s['name'] }}</option>
+                    {% endfor %}
+                </select>
+            </label>
+            <label class="block">Locations:
+                <select multiple name="new_group_locs" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                    {% for loc in locations %}
+                    <option value="{{ loc['id'] }}">{{ loc['name'] }}</option>
                     {% endfor %}
                 </select>
             </label>
@@ -417,27 +445,6 @@
             <label class="block">New Location Name:
                 <input type="text" name="new_location_name" class="border border-emerald-300 rounded-lg p-2.5 w-full">
             </label>
-            <div class="pt-4">
-                <h3 class="font-semibold">Restrictions</h3>
-                {% for s in students %}
-                <label class="block">{{ s['name'] }}:
-                    <select multiple name="student_locs_{{ s['id'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
-                        {% for loc in locations %}
-                        <option value="{{ loc['id'] }}" {% if loc['id'] in student_loc_map.get(s['id'], []) %}selected{% endif %}>{{ loc['name'] }}</option>
-                        {% endfor %}
-                    </select>
-                </label>
-                {% endfor %}
-                {% for g in groups %}
-                <label class="block">{{ g['name'] }} (Group):
-                    <select multiple name="group_locs_{{ g['id'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
-                        {% for loc in locations %}
-                        <option value="{{ loc['id'] }}" {% if loc['id'] in group_loc_map.get(g['id'], []) %}selected{% endif %}>{{ loc['name'] }}</option>
-                        {% endfor %}
-                    </select>
-                </label>
-                {% endfor %}
-            </div>
         </fieldset>
     </div>
     <!-- Unavailability -->

--- a/templates/edit_timetable.html
+++ b/templates/edit_timetable.html
@@ -26,7 +26,7 @@
                     <tr>
                         <th class="px-4 py-2 border">Slot</th>
                         {% for t in teachers %}
-                        <th class="px-4 py-2 border">{{ t['name'] }}</th>
+                        <th class="px-4 py-2 border">{{ t['name'] }}<br>{{ ', '.join(json.loads(t['subjects'])) }}</th>
                         {% endfor %}
                     </tr>
                 </thead>
@@ -40,6 +40,7 @@
                             <td class="px-4 py-2 border align-top">
                                 {% if entry %}
                                     <div>{{ entry.desc }}</div>
+                                    <button type="button" class="text-blue-600 hover:underline text-xs edit-lesson-btn" data-entry="{{ entry.id }}" data-student="{{ entry.student_id or '' }}" data-group="{{ entry.group_id or '' }}" data-subject="{{ entry.subject }}" data-location="{{ entry.location_id or '' }}">Edit</button>
                                     <form method="post" class="delete-lesson-form mt-1">
                                         <input type="hidden" name="action" value="delete">
                                         <input type="hidden" name="entry_id" value="{{ entry.id }}">
@@ -109,9 +110,64 @@
                     {% endfor %}
                 </select>
               </div>
+              <div class="mb-4">
+                <label class="block text-sm font-medium mb-1">Location</label>
+                <select name="location" class="border rounded w-full p-1">
+                    <option value="">-- None --</option>
+                    {% for loc in locations %}
+                    <option value="{{ loc['id'] }}">{{ loc['name'] }}</option>
+                    {% endfor %}
+                </select>
+              </div>
               <div class="flex justify-end">
                 <button type="submit" class="bg-emerald-500 text-white border rounded-md px-3 py-2 hover:bg-emerald-600 transition">Save</button>
                 <button type="button" data-modal-hide="add-modal" class="ml-2 text-emerald-700 hover:underline">Cancel</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Modal for editing lessons -->
+    <div id="edit-modal" tabindex="-1" class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full">
+      <div class="relative p-4 w-full max-w-md max-h-full">
+        <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
+          <div class="p-6">
+            <form method="post" id="edit-form">
+              <input type="hidden" name="action" value="edit">
+              <input type="hidden" name="entry_id" id="entry-id-input">
+              <div class="mb-4">
+                <label class="block text-sm font-medium mb-1">Student/Group</label>
+                <select name="student_group" id="edit-student-group" class="border rounded w-full p-1">
+                    {% for s in students %}
+                    <option value="s{{ s['id'] }}">Student: {{ s['name'] }}</option>
+                    {% endfor %}
+                    {% for g in groups %}
+                    <option value="g{{ g['id'] }}">Group: {{ g['name'] }}</option>
+                    {% endfor %}
+                </select>
+              </div>
+              <div class="mb-4">
+                <label class="block text-sm font-medium mb-1">Subject</label>
+                <select name="subject" id="edit-subject" class="border rounded w-full p-1">
+                    {% for sub in subjects %}
+                    <option value="{{ sub }}">{{ sub }}</option>
+                    {% endfor %}
+                </select>
+              </div>
+              <div class="mb-4">
+                <label class="block text-sm font-medium mb-1">Location</label>
+                <select name="location" id="edit-location" class="border rounded w-full p-1">
+                    <option value="">-- None --</option>
+                    {% for loc in locations %}
+                    <option value="{{ loc['id'] }}">{{ loc['name'] }}</option>
+                    {% endfor %}
+                </select>
+              </div>
+              <div class="flex justify-end">
+                <button type="submit" class="bg-emerald-500 text-white border rounded-md px-3 py-2 hover:bg-emerald-600 transition">Save</button>
+                <button type="button" data-modal-hide="edit-modal" class="ml-2 text-emerald-700 hover:underline">Cancel</button>
               </div>
             </form>
           </div>

--- a/tests/test_edit_timetable.py
+++ b/tests/test_edit_timetable.py
@@ -1,0 +1,76 @@
+import os
+import sys
+import sqlite3
+
+# ensure app can be imported
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+
+def setup_db(tmp_path):
+    import app
+    app.DB_PATH = str(tmp_path / 'test.db')
+    app.init_db()
+    conn = sqlite3.connect(app.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def test_add_and_edit_lesson(tmp_path):
+    import app
+    conn = setup_db(tmp_path)
+    c = conn.cursor()
+    c.execute("INSERT INTO locations (name) VALUES ('Room A')")
+    c.execute("INSERT INTO locations (name) VALUES ('Room B')")
+    conn.commit()
+    conn.close()
+
+    client = app.app.test_client()
+
+    # add lesson with location
+    resp = client.post('/edit_timetable/2024-01-01', data={
+        'action': 'add',
+        'slot': '0',
+        'teacher': '1',
+        'student_group': 's1',
+        'subject': 'Math',
+        'location': '1',
+    }, follow_redirects=True)
+    assert resp.status_code == 200
+
+    conn = sqlite3.connect(app.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    c = conn.cursor()
+    c.execute("SELECT id, student_id, subject, location_id FROM timetable WHERE date='2024-01-01'")
+    row = c.fetchone()
+    assert row['student_id'] == 1
+    assert row['subject'] == 'Math'
+    assert row['location_id'] == 1
+    entry_id = row['id']
+    c.execute("SELECT student_id, subject FROM attendance_log WHERE date='2024-01-01'")
+    log = c.fetchone()
+    assert log['student_id'] == 1 and log['subject'] == 'Math'
+    conn.close()
+
+    # edit lesson to different student, subject and location
+    resp = client.post('/edit_timetable/2024-01-01', data={
+        'action': 'edit',
+        'entry_id': str(entry_id),
+        'student_group': 's2',
+        'subject': 'English',
+        'location': '2',
+    }, follow_redirects=True)
+    assert resp.status_code == 200
+
+    conn = sqlite3.connect(app.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    c = conn.cursor()
+    c.execute("SELECT student_id, subject, location_id FROM timetable WHERE id=?", (entry_id,))
+    row = c.fetchone()
+    assert row['student_id'] == 2
+    assert row['subject'] == 'English'
+    assert row['location_id'] == 2
+    c.execute("SELECT student_id, subject FROM attendance_log WHERE date='2024-01-01'")
+    logs = c.fetchall()
+    assert len(logs) == 1
+    assert logs[0]['student_id'] == 2 and logs[0]['subject'] == 'English'
+    conn.close()

--- a/tests/test_location_restrictions.py
+++ b/tests/test_location_restrictions.py
@@ -1,0 +1,52 @@
+import os
+import sys
+
+# Ensure application package import
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+
+def setup_db(tmp_path):
+    import app, sqlite3
+    app.DB_PATH = str(tmp_path / 'test.db')
+    app.init_db()
+    conn = sqlite3.connect(app.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def test_new_entity_location_restrictions(tmp_path):
+    import app
+    conn = setup_db(tmp_path)
+    c = conn.cursor()
+    # create a location to reference
+    c.execute("INSERT INTO locations (name) VALUES ('Room A')")
+    conn.commit()
+
+    slot_starts = {f'slot_start_{i}': f'08:{30 + (i-1)*30:02d}' for i in range(1,9)}
+    data = {
+        'slots_per_day':'8', 'slot_duration':'30',
+        'min_lessons':'1', 'max_lessons':'4',
+        'teacher_min_lessons':'1', 'teacher_max_lessons':'8',
+        'max_repeats':'2', 'consecutive_weight':'3',
+        'attendance_weight':'10', 'well_attend_weight':'1',
+        'group_weight':'2.0', 'balance_weight':'1',
+        'new_student_name':'Charlie',
+        'new_student_subjects':['Math'],
+        'new_student_locs':['1'],
+        'new_group_name':'Group C',
+        'new_group_subjects':['Math'],
+        'new_group_members':['1'],
+        'new_group_locs':['1'],
+        **slot_starts,
+    }
+    with app.app.test_request_context('/config', method='POST', data=data):
+        app.config()
+
+    sid = conn.execute("SELECT id FROM students WHERE name='Charlie'").fetchone()['id']
+    s_loc = conn.execute('SELECT location_id FROM student_locations WHERE student_id=?', (sid,)).fetchone()
+    assert s_loc['location_id'] == 1
+
+    gid = conn.execute("SELECT id FROM groups WHERE name='Group C'").fetchone()['id']
+    g_loc = conn.execute('SELECT location_id FROM group_locations WHERE group_id=?', (gid,)).fetchone()
+    assert g_loc['location_id'] == 1
+    conn.close()


### PR DESCRIPTION
## Summary
- add support to assign locations when creating or editing lessons
- allow editing existing timetable entries for new student, subject or location
- show each teacher's subjects in edit timetable view and include location in lesson descriptions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6fd36151483228e1f169c678b29fd