### PR TITLE
Add location-based timetable view and UI enhancements

### DIFF
--- a/templates/edit_timetable.html
+++ b/templates/edit_timetable.html
@@ -79,7 +79,9 @@
         </ul>
         {% endif %}
 
-        <p class="text-center"><a href="{{ url_for('manage_timetables') }}" class="text-emerald-700 hover:underline">Back to Manage Timetables</a></p>
+        <div class="text-center">
+            <a href="{{ url_for('manage_timetables') }}" class="inline-block bg-emerald-500 text-white border rounded-md px-3 py-2 hover:bg-emerald-600 transition">Back to Manage Timetables</a>
+        </div>
     </div>
 
     <!-- Modal for adding lessons -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -64,6 +64,12 @@
                         <input datepicker datepicker-format="yyyy-mm-dd" datepicker-autohide="true" id="view-date" class="border border-emerald-300 rounded-lg block w-full ps-10 p-2.5" type="text" name="date" value="{{ today }}" placeholder="Select date">
                     </div>
                 </label>
+                <label class="block mb-4">Mode:
+                    <select name="mode" class="border border-emerald-300 rounded-lg block w-full p-2.5">
+                        <option value="teacher" {% if view_mode == 'teacher' %}selected{% endif %}>By Teacher</option>
+                        <option value="location" {% if view_mode == 'location' %}selected{% endif %}>By Location</option>
+                    </select>
+                </label>
             <button type="submit" class="w-full bg-emerald-500 text-white border rounded-md px-3 py-2 hover:bg-emerald-600 transition">View</button>
             </form>
         </div>
@@ -77,8 +83,14 @@
                     <thead class="text-xs text-emerald-800 uppercase bg-emerald-100 dark:bg-emerald-800 dark:text-emerald-200">
                         <tr>
                             <th scope="col" class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">Slot</th>
-                            {% for t in teachers %}
-                            <th scope="col" class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">{{ t['name'] }}<br>{{ ', '.join(json.loads(t['subjects'])) }}</th>
+                            {% for col in columns %}
+                            <th scope="col" class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">
+                                {% if view_mode == 'location' %}
+                                    {{ col['name'] }}
+                                {% else %}
+                                    {{ col['name'] }}<br>{{ ', '.join(json.loads(col['subjects'])) }}
+                                {% endif %}
+                            </th>
                             {% endfor %}
                         </tr>
                     </thead>
@@ -89,8 +101,8 @@
                             <th scope="row" class="px-4 py-2 font-medium text-emerald-900 whitespace-nowrap border border-emerald-200 dark:border-emerald-700 dark:text-white">
                                 Slot {{ slot + 1 }}<br>{{ label.start }}-{{ label.end }}
                             </th>
-                            {% for t in teachers %}
-                            <td class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">{{ grid[slot][t['id']] or '' }}</td>
+                            {% for col in columns %}
+                            <td class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">{{ grid[slot][col['id']] or '' }}</td>
                             {% endfor %}
                         </tr>
                         {% endfor %}

--- a/templates/timetable.html
+++ b/templates/timetable.html
@@ -20,16 +20,22 @@
     <table border="1" cellpadding="5">
         <tr>
             <th>Slot</th>
-            {% for t in teachers %}
-            <th>{{ t['name'] }}<br>{{ ', '.join(json.loads(t['subjects'])) }}</th>
+            {% for col in columns %}
+            <th>
+                {% if view_mode == 'location' %}
+                    {{ col['name'] }}
+                {% else %}
+                    {{ col['name'] }}<br>{{ ', '.join(json.loads(col['subjects'])) }}
+                {% endif %}
+            </th>
             {% endfor %}
         </tr>
         {% for slot in slots %}
         {% set label = slot_labels[slot] %}
         <tr>
             <td>Slot {{ slot + 1 }}<br>{{ label.start }}-{{ label.end }}</td>
-            {% for t in teachers %}
-            <td>{{ grid[slot][t['id']] or '' }}</td>
+            {% for col in columns %}
+            <td>{{ grid[slot][col['id']] or '' }}</td>
             {% endfor %}
         </tr>
         {% endfor %}

--- a/tests/test_location_display.py
+++ b/tests/test_location_display.py
@@ -28,3 +28,19 @@ def test_location_shown_in_timetable_grid(tmp_path):
     (_, _, teachers, grid, _, _, _, _, _) = app.get_timetable_data('2024-01-01')
     # timetable entry for teacher 1 in slot 0 should include the location name
     assert 'Room A' in grid[0][teachers[0]['id']]
+
+
+def test_location_view_groups_by_location(tmp_path):
+    import app
+    conn = setup_db(tmp_path)
+    c = conn.cursor()
+    c.execute("INSERT INTO locations (name) VALUES ('Room A')")
+    c.execute(
+        "INSERT INTO timetable (student_id, teacher_id, subject, slot, location_id, date) VALUES (1, 1, 'Math', 0, 1, '2024-01-01')"
+    )
+    conn.commit()
+    conn.close()
+
+    (_, _, locations, grid, _, _, _, _, _) = app.get_timetable_data('2024-01-01', view='location')
+    assert locations[0]['name'] == 'Room A'
+    assert grid[0][locations[0]['id']] == 'Student 1 (Math) with Teacher A'


### PR DESCRIPTION
## Summary
- Convert "Back to Manage Timetables" link into a styled button
- Support viewing timetables grouped by location or teacher, with new mode selector
- Add tests for location-based timetable rendering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8f15b92008322a05a99e02e1f4d53