### PR TITLE
Add location view without subjects

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -68,7 +68,7 @@
                     <select name="mode" class="border border-emerald-300 rounded-lg block w-full p-2.5">
                         <option value="teacher" {% if view_mode == 'teacher' %}selected{% endif %}>By Teacher</option>
                         <option value="location" {% if view_mode == 'location' %}selected{% endif %}>By Location</option>
-                        <option value="patient_only" {% if view_mode == 'patient_only' %}selected{% endif %}>Patient Only</option>
+                        <option value="patient_only" {% if view_mode == 'patient_only' %}selected{% endif %}>By Location (Patient Only)</option>
                     </select>
                 </label>
                 <button type="submit" class="mt-auto w-full bg-emerald-500 text-white border rounded-md px-3 py-2 hover:bg-emerald-600 transition">View</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -68,7 +68,7 @@
                     <select name="mode" class="border border-emerald-300 rounded-lg block w-full p-2.5">
                         <option value="teacher" {% if view_mode == 'teacher' %}selected{% endif %}>By Teacher</option>
                         <option value="location" {% if view_mode == 'location' %}selected{% endif %}>By Location</option>
-                        <option value="location_nosubject" {% if view_mode == 'location_nosubject' %}selected{% endif %}>By Location (No Subject)</option>
+                        <option value="patient_only" {% if view_mode == 'patient_only' %}selected{% endif %}>Patient Only</option>
                     </select>
                 </label>
                 <button type="submit" class="mt-auto w-full bg-emerald-500 text-white border rounded-md px-3 py-2 hover:bg-emerald-600 transition">View</button>
@@ -86,7 +86,7 @@
                             <th scope="col" class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">Slot</th>
                             {% for col in columns %}
                             <th scope="col" class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">
-                                {% if view_mode.startswith('location') %}
+                                {% if view_mode in ['location', 'patient_only'] %}
                                     {{ col['name'] }}
                                 {% else %}
                                     {{ col['name'] }}<br>{{ ', '.join(json.loads(col['subjects'])) }}

--- a/templates/index.html
+++ b/templates/index.html
@@ -68,6 +68,7 @@
                     <select name="mode" class="border border-emerald-300 rounded-lg block w-full p-2.5">
                         <option value="teacher" {% if view_mode == 'teacher' %}selected{% endif %}>By Teacher</option>
                         <option value="location" {% if view_mode == 'location' %}selected{% endif %}>By Location</option>
+                        <option value="location_nosubject" {% if view_mode == 'location_nosubject' %}selected{% endif %}>By Location (No Subject)</option>
                     </select>
                 </label>
                 <button type="submit" class="mt-auto w-full bg-emerald-500 text-white border rounded-md px-3 py-2 hover:bg-emerald-600 transition">View</button>
@@ -85,7 +86,7 @@
                             <th scope="col" class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">Slot</th>
                             {% for col in columns %}
                             <th scope="col" class="px-4 py-2 border border-emerald-200 dark:border-emerald-700">
-                                {% if view_mode == 'location' %}
+                                {% if view_mode.startswith('location') %}
                                     {{ col['name'] }}
                                 {% else %}
                                     {{ col['name'] }}<br>{{ ', '.join(json.loads(col['subjects'])) }}

--- a/templates/timetable.html
+++ b/templates/timetable.html
@@ -22,7 +22,7 @@
             <th>Slot</th>
             {% for col in columns %}
             <th>
-                {% if view_mode == 'location' %}
+                {% if view_mode.startswith('location') %}
                     {{ col['name'] }}
                 {% else %}
                     {{ col['name'] }}<br>{{ ', '.join(json.loads(col['subjects'])) }}

--- a/templates/timetable.html
+++ b/templates/timetable.html
@@ -22,7 +22,7 @@
             <th>Slot</th>
             {% for col in columns %}
             <th>
-                {% if view_mode.startswith('location') %}
+                {% if view_mode in ['location', 'patient_only'] %}
                     {{ col['name'] }}
                 {% else %}
                     {{ col['name'] }}<br>{{ ', '.join(json.loads(col['subjects'])) }}

--- a/tests/test_location_display.py
+++ b/tests/test_location_display.py
@@ -46,7 +46,7 @@ def test_location_view_groups_by_location(tmp_path):
     assert grid[0][locations[0]['id']] == 'Student 1 (Math) with Teacher A'
 
 
-def test_location_view_without_subject(tmp_path):
+def test_patient_only_view(tmp_path):
     import app
     conn = setup_db(tmp_path)
     c = conn.cursor()
@@ -57,5 +57,5 @@ def test_location_view_without_subject(tmp_path):
     conn.commit()
     conn.close()
 
-    (_, _, locations, grid, _, _, _, _, _) = app.get_timetable_data('2024-01-01', view='location_nosubject')
-    assert grid[0][locations[0]['id']] == 'Student 1 with Teacher A'
+    (_, _, locations, grid, _, _, _, _, _) = app.get_timetable_data('2024-01-01', view='patient_only')
+    assert grid[0][locations[0]['id']] == 'Student 1'

--- a/tests/test_location_display.py
+++ b/tests/test_location_display.py
@@ -44,3 +44,18 @@ def test_location_view_groups_by_location(tmp_path):
     (_, _, locations, grid, _, _, _, _, _) = app.get_timetable_data('2024-01-01', view='location')
     assert locations[0]['name'] == 'Room A'
     assert grid[0][locations[0]['id']] == 'Student 1 (Math) with Teacher A'
+
+
+def test_location_view_without_subject(tmp_path):
+    import app
+    conn = setup_db(tmp_path)
+    c = conn.cursor()
+    c.execute("INSERT INTO locations (name) VALUES ('Room A')")
+    c.execute(
+        "INSERT INTO timetable (student_id, teacher_id, subject, slot, location_id, date) VALUES (1, 1, 'Math', 0, 1, '2024-01-01')"
+    )
+    conn.commit()
+    conn.close()
+
+    (_, _, locations, grid, _, _, _, _, _) = app.get_timetable_data('2024-01-01', view='location_nosubject')
+    assert grid[0][locations[0]['id']] == 'Student 1 with Teacher A'


### PR DESCRIPTION
## Summary
- support new `location_nosubject` mode in `get_timetable_data` for viewing timetables by location without subject names
- expose new view in the UI and handle location-based modes consistently
- cover location view without subject with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9306bea688322a45f1c45fc543e21