### PR TITLE
Fix Python launcher detection

### DIFF
--- a/run_app.bat
+++ b/run_app.bat
@@ -9,10 +9,9 @@ echo === Timetabling App Launcher ===
 
 REM Prefer python, fall back to py -3 if needed
 set "PYCMD=python"
-where %PYCMD% >nul 2>nul
+where python >nul 2>nul
 if errorlevel 1 (
-  set "PYCMD=py -3"
-  where %PYCMD% >nul 2>nul
+  where py >nul 2>nul
   if errorlevel 1 (
     echo.
     echo [ERROR] Python was not found on PATH.
@@ -20,6 +19,7 @@ if errorlevel 1 (
     pause
     exit /b 1
   )
+  set "PYCMD=py -3"
 )
 
 REM Create virtual environment if missing


### PR DESCRIPTION
## Summary
- fix launcher to detect Python when only `py` is available

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc07b468bc83228eb8aac5b049863f