### PR TITLE
Prioritize lowest attendance percentages in scheduling

### DIFF
--- a/app.py
+++ b/app.py
@@ -1750,10 +1750,13 @@ def generate_schedule(target_date=None):
             for subj in required:
                 perc = (counts.get(subj, 0) / total * 100) if total else 0
                 attendance_pct.setdefault(sid, {})[subj] = perc
-                if perc < min_map.get(subj, 0):
-                    subject_weights[(sid, subj)] = 1 + attendance_weight
+                min_val = min_map.get(subj, 0)
+                if perc < min_val and min_val > 0:
+                    deficit = (min_val - perc) / min_val
+                    weight = well_attend_weight + attendance_weight * deficit
                 else:
-                    subject_weights[(sid, subj)] = well_attend_weight
+                    weight = well_attend_weight
+                subject_weights[(sid, subj)] = weight
         for g in groups:
             gid = g['id']
             gsubs = json.loads(g['subjects'])
@@ -1764,8 +1767,10 @@ def generate_schedule(target_date=None):
                     med = statistics.median(sorted(percs))
                 else:
                     med = 0
-                if med < min_map.get(subj, 0):
-                    weight = 1 + attendance_weight
+                min_val = min_map.get(subj, 0)
+                if med < min_val and min_val > 0:
+                    deficit = (min_val - med) / min_val
+                    weight = well_attend_weight + attendance_weight * deficit
                 else:
                     weight = well_attend_weight
                 subject_weights[(offset + gid, subj)] = weight

--- a/templates/config.html
+++ b/templates/config.html
@@ -101,7 +101,7 @@
             <ul class="list-disc ms-6 mb-4">
                 <li><strong>consecutive_weight</strong>: Reward for consecutive repeats (typical 0–10). 0 disables the preference.</li>
                 <li><strong>balance_weight</strong>: Penalty on the gap between most/least busy teachers (typical 0–10). 0 disables load balancing.</li>
-                <li><strong>attendance_weight</strong>: Extra weight for subjects where a student (or group median) is below the subject’s Min% target (typical 0–20).</li>
+                <li><strong>attendance_weight</strong>: Maximum extra weight for subjects below a subject’s Min% target; the actual weight grows as the attendance percentage falls short (typical 0–20).</li>
                 <li><strong>well_attend_weight</strong>: Weight to use for subjects already meeting the Min% target (typical 0.5–2.0).</li>
                 <li><strong>group_weight</strong>: Multiplier for group lessons to bias scheduling toward groups (typical 1.0–3.0). Set to 0 to remove the bias.</li>
             </ul>
@@ -109,7 +109,7 @@
             <p class="mb-2"><strong>Attendance Priority</strong> (optional):</p>
             <ul class="list-disc ms-6 mb-4">
                 <li>Enable <em>Attendance Priority</em> to favor subjects where a student’s attendance % is below the <em>Subjects → Min %</em> threshold.</li>
-                <li>Weights used are <em>attendance_weight</em> (below target) and <em>well_attend_weight</em> (at/above target).</li>
+                <li>Weights for below-target subjects scale from <em>well_attend_weight</em> up to <em>well_attend_weight</em> + <em>attendance_weight</em> based on how far the attendance percentage is from the target.</li>
                 <li>For groups, the median attendance among members is used to decide the weight.</li>
                 <li>Note: Combining <em>Require All Subjects</em> and <em>Attendance Priority</em> can slow solving.</li>
             </ul>


### PR DESCRIPTION
## Summary
- Scale attendance weights by how far a student or group is below the subject's minimum percentage
- Update configuration help text to clarify scaled attendance priority weights

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3bbee6dac832299a8debedde32091