### PR TITLE
Add subject archive table to preserve timetable history

### DIFF
--- a/CODE_GUIDE.txt
+++ b/CODE_GUIDE.txt
@@ -43,7 +43,7 @@ This module isolates the OR-Tools logic from the web code. ``build_model`` const
 
 The function can also attach assumption indicators to major constraint groups. When enabled, these indicators help explain which group caused the model to be infeasible.
 
-``solve_and_print`` runs the solver and extracts the assignments that were set to ``True``. If the model was infeasible and assumptions were used, it returns the names of the conflicting groups.
+``solve_and_print`` runs the solver, emitting progress messages for each feasible solution (higher scores indicate better timetables). It returns the chosen assignments, any conflicting assumption groups, and the list of progress messages.
 
 Static files and templates
 --------------------------

--- a/cp_sat_timetable.py
+++ b/cp_sat_timetable.py
@@ -404,7 +404,7 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
     return model, vars_, loc_vars, assumptions
 
 
-def solve_and_print(model, vars_, loc_vars, assumptions=None):
+def solve_and_print(model, vars_, loc_vars, assumptions=None, time_limit=None, progress_callback=None):
     """Run the OR-Tools solver and collect the results.
 
     Args:
@@ -415,6 +415,9 @@ def solve_and_print(model, vars_, loc_vars, assumptions=None):
         assumptions: Optional dictionary of assumption indicators.  When the
             model is infeasible these help identify which group of constraints
             caused the problem.
+        time_limit: Optional maximum solving time in seconds.
+        progress_callback: Optional callable invoked with a progress message
+            each time the solver finds a better solution.
 
     Returns:
         ``status``: Solver status value from OR-Tools.
@@ -423,23 +426,39 @@ def solve_and_print(model, vars_, loc_vars, assumptions=None):
         locations.
         ``core``: If infeasible and assumptions were used, names of the
         constraint groups that could not be satisfied.
+        ``progress``: List of textual progress messages describing each
+        improved solution encountered during search.
     """
 
     # Instantiate the solver and let it process the model.
     solver = cp_model.CpSolver()
-    # Solve with assumptions if API supports it; otherwise rely on AddAssumption + Solve.
-    if assumptions and hasattr(solver, 'SolveWithAssumptions'):
-        # Use a fixed key order for stable core mapping
-        assumption_keys = [
-            'teacher_availability',
-            'teacher_limits',
-            'student_limits',
-            'repeat_restrictions',
-        ]
-        assumption_list = [assumptions[k] for k in assumption_keys if k in assumptions]
-        status = solver.SolveWithAssumptions(model, assumption_list)
-    else:
-        status = solver.Solve(model)
+    if time_limit is not None:
+        # ``max_time_in_seconds`` is the canonical wall time limit used by OR-Tools.
+        solver.parameters.max_time_in_seconds = time_limit
+
+    progress = []
+
+    class _ProgressCollector(cp_model.CpSolverSolutionCallback):
+        def __init__(self, limit):
+            super().__init__()
+            self._count = 0
+            self._limit = limit
+
+        def OnSolutionCallback(self):
+            self._count += 1
+            msg = f"Solution {self._count}: score {self.ObjectiveValue():.1f} (higher is better)"
+            progress.append(msg)
+            if progress_callback:
+                progress_callback(msg)
+            # ``WallTime`` is measured in seconds and allows us to stop the
+            # search if the solver's internal limit fails for any reason.
+            if self._limit is not None and self.WallTime() >= self._limit:
+                self.StopSearch()
+
+    callback = _ProgressCollector(time_limit)
+
+    # Solve the model while tracking progress using the modern ``solve`` API.
+    status = solver.solve(model, callback)
 
     assignments = []
     if status in (cp_model.OPTIMAL, cp_model.FEASIBLE):
@@ -469,4 +488,4 @@ def solve_and_print(model, vars_, loc_vars, assumptions=None):
 
     # ``core`` gives a minimal set of unsatisfied assumption groups when no
     # feasible schedule exists.  ``assignments`` is empty in that case.
-    return status, assignments, core
+    return status, assignments, core, progress

--- a/templates/config.html
+++ b/templates/config.html
@@ -217,6 +217,9 @@
             <label class="block">Balance weight:
                 <input type="number" name="balance_weight" value="{{ config['balance_weight'] }}" min="1" class="border border-emerald-300 rounded-lg p-2.5 w-full">
             </label>
+            <label class="block">Solver time limit (seconds):
+                <input type="number" name="solver_time_limit" value="{{ config['solver_time_limit']|default(120, true) }}" min="1" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+            </label>
         </fieldset>
     </div>
     <!-- Subjects -->

--- a/tests/test_delete_subject_archives.py
+++ b/tests/test_delete_subject_archives.py
@@ -1,0 +1,71 @@
+import os
+import sys
+import sqlite3
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+
+def setup_db(tmp_path):
+    import app
+    app.DB_PATH = str(tmp_path / 'test.db')
+    app.init_db()
+    conn = sqlite3.connect(app.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def test_deleting_subject_archives(tmp_path):
+    import app
+    conn = setup_db(tmp_path)
+    c = conn.cursor()
+    c.execute('DELETE FROM subjects')
+    c.execute('DELETE FROM subjects_archive')
+    c.execute('DELETE FROM timetable')
+    conn.commit()
+    c.execute("INSERT INTO subjects (id, name, min_percentage) VALUES (1, 'Sub', 0)")
+    c.execute(
+        "INSERT INTO timetable (date, slot, student_id, teacher_id, subject_id, group_id, location_id) "
+        "VALUES ('2024-01-01', 0, NULL, NULL, 1, NULL, NULL)"
+    )
+    conn.commit()
+    conn.close()
+
+    slot_starts = {f'slot_start_{i}': f'08:{30 + (i-1)*30:02d}' for i in range(1, 9)}
+    data = {
+        'slots_per_day': '8',
+        'slot_duration': '30',
+        'min_lessons': '1',
+        'max_lessons': '4',
+        'teacher_min_lessons': '1',
+        'teacher_max_lessons': '8',
+        'max_repeats': '2',
+        'consecutive_weight': '3',
+        'attendance_weight': '10',
+        'well_attend_weight': '1',
+        'group_weight': '2',
+        'balance_weight': '1',
+        'subject_id': '1',
+        'subject_delete': '1',
+        'subject_name_1': 'Sub',
+        'subject_min_1': '0',
+        **slot_starts,
+    }
+    with app.app.test_request_context('/config', method='POST', data=data):
+        app.config()
+
+    conn = sqlite3.connect(app.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    c = conn.cursor()
+    assert c.execute('SELECT COUNT(*) FROM subjects WHERE id=1').fetchone()[0] == 0
+    assert c.execute('SELECT name FROM subjects_archive WHERE id=1').fetchone()[0] == 'Sub'
+    row = c.execute(
+        """
+        SELECT COALESCE(sub.name, suba.name) AS subject
+        FROM timetable t
+        LEFT JOIN subjects sub ON t.subject_id = sub.id
+        LEFT JOIN subjects_archive suba ON t.subject_id = suba.id
+        """
+    ).fetchone()
+    assert row['subject'] == 'Sub'
+    conn.close()
+

--- a/tests/test_deleted_subject_not_recreated.py
+++ b/tests/test_deleted_subject_not_recreated.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import sqlite3
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+
+def setup_db(tmp_path):
+    import app
+    app.DB_PATH = str(tmp_path / 'test.db')
+    app.init_db()
+    conn = sqlite3.connect(app.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def test_deleted_subject_not_recreated(tmp_path):
+    import app
+
+    conn = setup_db(tmp_path)
+    c = conn.cursor()
+    # ensure clean state
+    c.execute('DELETE FROM subjects')
+    c.execute('DELETE FROM subjects_archive')
+    c.execute('DELETE FROM teachers')
+    conn.commit()
+
+    # create subject and teacher referencing it
+    c.execute("INSERT INTO subjects (id, name) VALUES (1, 'Sub')")
+    c.execute("INSERT INTO teachers (id, name, subjects) VALUES (1, 'T', '[1]')")
+    conn.commit()
+
+    # delete subject and close connection
+    c.execute('DELETE FROM subjects WHERE id=1')
+    conn.commit()
+    conn.close()
+
+    # re-run init to trigger cleanup
+    app.init_db()
+
+    conn = sqlite3.connect(app.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    c = conn.cursor()
+    # subject should not be recreated with numeric name
+    assert c.execute('SELECT COUNT(*) FROM subjects').fetchone()[0] == 0
+    # teacher's subject list should be cleared
+    assert c.execute('SELECT subjects FROM teachers WHERE id=1').fetchone()['subjects'] == '[]'
+    conn.close()
+

--- a/tests/test_fixed_assignment_subject_id.py
+++ b/tests/test_fixed_assignment_subject_id.py
@@ -17,7 +17,8 @@ def test_fixed_assignment_handles_subject_id():
     model, vars_, loc_vars, _ = build_model(
         students, teachers, slots=1, min_lessons=0, max_lessons=1, fixed=fixed
     )
-    status, assignments, _ = solve_and_print(model, vars_, loc_vars)
+    status, assignments, _, progress = solve_and_print(model, vars_, loc_vars)
 
     # The fixed assignment should appear in the solver output
     assert (1, 1, 1, 0, None) in assignments
+    assert isinstance(progress, list)

--- a/tests/test_snapshot_lifecycle.py
+++ b/tests/test_snapshot_lifecycle.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import sqlite3
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+
+def setup_db(tmp_path):
+    import app
+    app.DB_PATH = str(tmp_path / 'test.db')
+    app.init_db()
+    conn = sqlite3.connect(app.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def test_generate_creates_snapshot(tmp_path):
+    import app
+    conn = setup_db(tmp_path)
+    conn.close()
+
+    client = app.app.test_client()
+    resp = client.post('/generate', data={'date': '2024-01-01', 'confirm': '1'}, follow_redirects=True)
+    assert resp.status_code == 200
+
+    conn = sqlite3.connect(app.DB_PATH)
+    row = conn.execute("SELECT 1 FROM timetable_snapshot WHERE date='2024-01-01'").fetchone()
+    conn.close()
+    assert row is not None
+
+
+def test_regenerate_updates_snapshot(tmp_path):
+    import app
+    conn = setup_db(tmp_path)
+    conn.close()
+
+    client = app.app.test_client()
+    resp = client.post('/generate', data={'date': '2024-01-01', 'confirm': '1'}, follow_redirects=True)
+    assert resp.status_code == 200
+
+    resp = client.post('/generate', data={'date': '2024-01-01', 'confirm': '1'}, follow_redirects=True)
+    assert resp.status_code == 200
+
+    conn = sqlite3.connect(app.DB_PATH)
+    row = conn.execute("SELECT 1 FROM timetable_snapshot WHERE date='2024-01-01'").fetchone()
+    conn.close()
+    assert row is not None
+
+
+def test_delete_timetables_removes_snapshot(tmp_path):
+    import app
+    conn = setup_db(tmp_path)
+    c = conn.cursor()
+    c.execute("INSERT INTO timetable (student_id, teacher_id, subject_id, slot, date) VALUES (1, 1, 1, 0, '2024-01-01')")
+    app.get_missing_and_counts(c, '2024-01-01', refresh=True)
+    conn.commit()
+    conn.close()
+
+    client = app.app.test_client()
+    resp = client.post('/delete_timetables', data={'dates': ['2024-01-01']}, follow_redirects=True)
+    assert resp.status_code == 200
+
+    conn = sqlite3.connect(app.DB_PATH)
+    row = conn.execute("SELECT 1 FROM timetable_snapshot WHERE date='2024-01-01'").fetchone()
+    conn.close()
+    assert row is None

--- a/tools/backfill_snapshots.py
+++ b/tools/backfill_snapshots.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import sqlite3
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, BASE_DIR)
+from app import DB_PATH, get_missing_and_counts
+
+
+def backfill():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    c = conn.cursor()
+
+    dates = [row['date'] for row in c.execute('SELECT DISTINCT date FROM timetable')]
+    created = 0
+    for d in dates:
+        c.execute('SELECT 1 FROM timetable_snapshot WHERE date=?', (d,))
+        if c.fetchone() is None:
+            get_missing_and_counts(c, d, refresh=True)
+            created += 1
+    conn.commit()
+    conn.close()
+    print(f"Created {created} snapshot(s).")
+
+
+if __name__ == '__main__':
+    backfill()

--- a/tools/cleanup_snapshots.py
+++ b/tools/cleanup_snapshots.py
@@ -1,0 +1,76 @@
+import os
+import sys
+import json
+import sqlite3
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, BASE_DIR)
+from app import DB_PATH
+
+
+def cleanup():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    c = conn.cursor()
+
+    # Deduplicate rows by keeping the first row per date
+    c.execute(
+        """
+        DELETE FROM timetable_snapshot
+        WHERE rowid NOT IN (
+            SELECT MIN(rowid) FROM timetable_snapshot GROUP BY date
+        )
+        """
+    )
+    removed_dups = c.rowcount
+
+    # Remove snapshots for dates that no longer have timetable entries
+    c.execute(
+        """
+        DELETE FROM timetable_snapshot
+        WHERE date NOT IN (SELECT DISTINCT date FROM timetable)
+        """
+    )
+    removed_orphaned = c.rowcount
+
+    rows = c.execute("SELECT date, missing FROM timetable_snapshot").fetchall()
+    dates_to_delete = []
+    for row in rows:
+        missing = row["missing"]
+        if not missing:
+            continue
+        try:
+            data = json.loads(missing)
+        except json.JSONDecodeError:
+            dates_to_delete.append(row["date"])
+            continue
+        outdated = False
+        for subjects in data.values():
+            for entry in subjects:
+                if not isinstance(entry, dict) or "subject_id" not in entry:
+                    outdated = True
+                    break
+            if outdated:
+                break
+        if outdated:
+            dates_to_delete.append(row["date"])
+
+    if dates_to_delete:
+        c.executemany(
+            "DELETE FROM timetable_snapshot WHERE date = ?",
+            [(d,) for d in dates_to_delete],
+        )
+
+    removed_outdated = len(dates_to_delete)
+
+    conn.commit()
+    print(
+        "Deduplicated {0} rows, removed {1} orphaned snapshots and {2} outdated snapshots".format(
+            removed_dups, removed_orphaned, removed_outdated
+        )
+    )
+    conn.close()
+
+
+if __name__ == "__main__":
+    cleanup()


### PR DESCRIPTION
## Summary
- Create `subjects_archive` table and include in configuration dump/restore
- Archive subject names on deletion and restore missing entries when loading presets
- Ensure timetable and attendance views fall back to archived subject names
- Add tests for subject deletion and preset restoration to verify archives

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4c6d4e1508322a86a4b751eecbc8e