### PR TITLE
Add snapshot cleanup utility

### DIFF
--- a/CODE_GUIDE.txt
+++ b/CODE_GUIDE.txt
@@ -43,7 +43,7 @@ This module isolates the OR-Tools logic from the web code. ``build_model`` const
 
 The function can also attach assumption indicators to major constraint groups. When enabled, these indicators help explain which group caused the model to be infeasible.
 
-``solve_and_print`` runs the solver and extracts the assignments that were set to ``True``. If the model was infeasible and assumptions were used, it returns the names of the conflicting groups.
+``solve_and_print`` runs the solver, emitting progress messages for each feasible solution (higher scores indicate better timetables). It returns the chosen assignments, any conflicting assumption groups, and the list of progress messages.
 
 Static files and templates
 --------------------------

--- a/app.py
+++ b/app.py
@@ -1740,10 +1740,11 @@ def generate_schedule(target_date=None):
     for r in gl_rows:
         group_loc_map.setdefault(r['group_id'], set()).add(r['location_id'])
 
-    # clear previous timetable, attendance logs, and worksheet assignments for the target date
+    # clear previous timetable, attendance logs, worksheet assignments, and snapshot for the target date
     c.execute('DELETE FROM timetable WHERE date=?', (target_date,))
     c.execute('DELETE FROM attendance_log WHERE date=?', (target_date,))
     c.execute('DELETE FROM worksheets WHERE date=?', (target_date,))
+    c.execute('DELETE FROM timetable_snapshot WHERE date=?', (target_date,))
 
     # Build and solve CP-SAT model
     allow_repeats = bool(cfg['allow_repeats'])
@@ -2065,6 +2066,7 @@ def generate():
         conn.execute('DELETE FROM timetable WHERE date=?', (gen_date,))
         conn.execute('DELETE FROM attendance_log WHERE date=?', (gen_date,))
         conn.execute('DELETE FROM worksheets WHERE date=?', (gen_date,))
+        conn.execute('DELETE FROM timetable_snapshot WHERE date=?', (gen_date,))
         conn.commit()
         conn.close()
     generate_schedule(gen_date)
@@ -2544,6 +2546,7 @@ def delete_timetables():
         c.execute('DELETE FROM timetable')
         c.execute('DELETE FROM attendance_log')
         c.execute('DELETE FROM worksheets')
+        c.execute('DELETE FROM timetable_snapshot')
         conn.commit()
         conn.close()
         flash('All timetables deleted.', 'info')
@@ -2555,6 +2558,7 @@ def delete_timetables():
             c.execute('DELETE FROM timetable WHERE date=?', (d,))
             c.execute('DELETE FROM attendance_log WHERE date=?', (d,))
             c.execute('DELETE FROM worksheets WHERE date=?', (d,))
+            c.execute('DELETE FROM timetable_snapshot WHERE date=?', (d,))
         conn.commit()
         conn.close()
         flash(f'Deleted timetables for {len(dates)} date(s).', 'info')

--- a/app.py
+++ b/app.py
@@ -1905,7 +1905,6 @@ def generate_schedule(target_date=None):
             flash('No feasible timetable could be generated.', 'error')
             for name in core:
                 flash(reason_map.get(name, name), 'error')
-    get_missing_and_counts(c, target_date, refresh=True)
     conn.commit()
     conn.close()
 
@@ -2070,6 +2069,11 @@ def generate():
         conn.commit()
         conn.close()
     generate_schedule(gen_date)
+    conn = get_db()
+    c = conn.cursor()
+    get_missing_and_counts(c, gen_date, refresh=True)
+    conn.commit()
+    conn.close()
     return redirect(url_for('index', date=gen_date))
 
 

--- a/app.py
+++ b/app.py
@@ -122,7 +122,8 @@ def init_db():
             allow_multi_teacher INTEGER,
             balance_teacher_load INTEGER,
             balance_weight INTEGER,
-            well_attend_weight REAL
+            well_attend_weight REAL,
+            solver_time_limit INTEGER DEFAULT 120
         )''')
     else:
         if not column_exists('config', 'slot_start_times'):
@@ -143,6 +144,8 @@ def init_db():
             c.execute('ALTER TABLE config ADD COLUMN balance_weight INTEGER DEFAULT 1')
         if not column_exists('config', 'well_attend_weight'):
             c.execute('ALTER TABLE config ADD COLUMN well_attend_weight REAL DEFAULT 1')
+        if not column_exists('config', 'solver_time_limit'):
+            c.execute('ALTER TABLE config ADD COLUMN solver_time_limit INTEGER DEFAULT 120')
 
     if not table_exists('teachers'):
         c.execute('''CREATE TABLE teachers (
@@ -564,8 +567,8 @@ def init_db():
             prefer_consecutive, allow_consecutive, consecutive_weight,
             require_all_subjects, use_attendance_priority, attendance_weight, group_weight,
             allow_multi_teacher, balance_teacher_load, balance_weight,
-            well_attend_weight
-        ) VALUES (1, 8, 30, ?, 1, 4, 1, 8, 0, 2, 0, 1, 3, 1, 0, 10, 2.0, 1, 0, 1, 1)''',
+            well_attend_weight, solver_time_limit
+        ) VALUES (1, 8, 30, ?, 1, 4, 1, 8, 0, 2, 0, 1, 3, 1, 0, 10, 2.0, 1, 0, 1, 1, 120)''',
                   (json.dumps(times),))
         subjects = [
             ('Math', 0),
@@ -617,7 +620,9 @@ def dump_configuration():
 
 def migrate_preset(preset):
     """Upgrade preset data from older versions to CURRENT_PRESET_VERSION."""
-    # Currently only version 1 exists. Future migrations will modify ``preset``.
+    data = preset.get('data', {})
+    for row in data.get('config', []):
+        row.setdefault('solver_time_limit', 120)
     return preset
 
 
@@ -631,8 +636,7 @@ def restore_configuration(preset, overwrite=False):
     version = preset.get('version', 0)
     if version > CURRENT_PRESET_VERSION:
         raise ValueError('Preset version is newer than supported.')
-    if version < CURRENT_PRESET_VERSION:
-        preset = migrate_preset(preset)
+    preset = migrate_preset(preset)
     conn = get_db()
     c = conn.cursor()
     current = dump_configuration()['data']
@@ -962,6 +966,18 @@ def config():
         allow_multi_teacher = 1 if request.form.get('allow_multi_teacher') else 0
         balance_teacher_load = 1 if request.form.get('balance_teacher_load') else 0
         balance_weight = int(request.form['balance_weight'])
+        solver_time_limit_raw = request.form.get('solver_time_limit', '').strip()
+        if solver_time_limit_raw:
+            try:
+                solver_time_limit = int(solver_time_limit_raw)
+                if solver_time_limit <= 0:
+                    raise ValueError
+            except ValueError:
+                flash('Solver time limit must be a positive integer', 'error')
+                has_error = True
+                solver_time_limit = c.execute('SELECT solver_time_limit FROM config WHERE id=1').fetchone()[0]
+        else:
+            solver_time_limit = c.execute('SELECT solver_time_limit FROM config WHERE id=1').fetchone()[0]
 
         if require_all_subjects and use_attendance_priority:
             flash(
@@ -989,14 +1005,14 @@ def config():
                      allow_repeats=?, max_repeats=?,
                      prefer_consecutive=?, allow_consecutive=?, consecutive_weight=?,
                      require_all_subjects=?, use_attendance_priority=?, attendance_weight=?,
-                     group_weight=?, well_attend_weight=?, allow_multi_teacher=?, balance_teacher_load=?, balance_weight=?
+                     group_weight=?, well_attend_weight=?, allow_multi_teacher=?, balance_teacher_load=?, balance_weight=?, solver_time_limit=?
                      WHERE id=1""",
                   (slots_per_day, slot_duration, json.dumps(start_times), min_lessons,
                    max_lessons, t_min_lessons, t_max_lessons,
                    allow_repeats, max_repeats, prefer_consecutive,
                    allow_consecutive, consecutive_weight, require_all_subjects,
                    use_attendance_priority, attendance_weight, group_weight, well_attend_weight,
-                   allow_multi_teacher, balance_teacher_load, balance_weight))
+                   allow_multi_teacher, balance_teacher_load, balance_weight, solver_time_limit))
         # update subjects
         subj_ids = request.form.getlist('subject_id')
         deletes_sub = set(request.form.getlist('subject_delete'))
@@ -1674,6 +1690,7 @@ def generate_schedule(target_date=None):
     max_lessons = cfg['max_lessons']
     teacher_min = cfg['teacher_min_lessons']
     teacher_max = cfg['teacher_max_lessons']
+    solver_time_limit = cfg['solver_time_limit']
 
     c.execute('SELECT * FROM teachers')
     teachers = c.fetchall()
@@ -1853,7 +1870,30 @@ def generate_schedule(target_date=None):
         student_multi_teacher=student_multi,
         locations=locations,
         location_restrict=loc_restrict)
-    status, assignments, core = solve_and_print(model, vars_, loc_vars, assumptions)
+
+    progress_messages = []
+
+    def progress_cb(msg):
+        progress_messages.append(msg)
+        app.logger.info(msg)
+
+    status, assignments, core, progress = solve_and_print(
+        model,
+        vars_,
+        loc_vars,
+        assumptions,
+        time_limit=solver_time_limit,
+        progress_callback=progress_cb,
+    )
+
+    from ortools.sat.python import cp_model
+    if status == cp_model.OPTIMAL:
+        flash('Optimal timetable found.', 'success')
+    elif status == cp_model.FEASIBLE:
+        flash('Feasible timetable found before time limit.', 'info')
+
+    for msg in progress:
+        flash(msg, 'info')
 
     # Insert solver results into DB
     if assignments:
@@ -1892,7 +1932,6 @@ def generate_schedule(target_date=None):
             c.executemany('INSERT INTO attendance_log (student_id, student_name, subject_id, date) VALUES (?, ?, ?, ?)',
                           attendance_rows)
     else:
-        from ortools.sat.python import cp_model
         if status == cp_model.INFEASIBLE:
             # Map assumption literals from the unsat core to human readable
             # messages explaining why the model is infeasible.

--- a/cp_sat_timetable.py
+++ b/cp_sat_timetable.py
@@ -404,7 +404,7 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
     return model, vars_, loc_vars, assumptions
 
 
-def solve_and_print(model, vars_, loc_vars, assumptions=None):
+def solve_and_print(model, vars_, loc_vars, assumptions=None, time_limit=None, progress_callback=None):
     """Run the OR-Tools solver and collect the results.
 
     Args:
@@ -415,6 +415,9 @@ def solve_and_print(model, vars_, loc_vars, assumptions=None):
         assumptions: Optional dictionary of assumption indicators.  When the
             model is infeasible these help identify which group of constraints
             caused the problem.
+        time_limit: Optional maximum solving time in seconds.
+        progress_callback: Optional callable invoked with a progress message
+            each time the solver finds a better solution.
 
     Returns:
         ``status``: Solver status value from OR-Tools.
@@ -423,23 +426,39 @@ def solve_and_print(model, vars_, loc_vars, assumptions=None):
         locations.
         ``core``: If infeasible and assumptions were used, names of the
         constraint groups that could not be satisfied.
+        ``progress``: List of textual progress messages describing each
+        improved solution encountered during search.
     """
 
     # Instantiate the solver and let it process the model.
     solver = cp_model.CpSolver()
-    # Solve with assumptions if API supports it; otherwise rely on AddAssumption + Solve.
-    if assumptions and hasattr(solver, 'SolveWithAssumptions'):
-        # Use a fixed key order for stable core mapping
-        assumption_keys = [
-            'teacher_availability',
-            'teacher_limits',
-            'student_limits',
-            'repeat_restrictions',
-        ]
-        assumption_list = [assumptions[k] for k in assumption_keys if k in assumptions]
-        status = solver.SolveWithAssumptions(model, assumption_list)
-    else:
-        status = solver.Solve(model)
+    if time_limit is not None:
+        # ``max_time_in_seconds`` is the canonical wall time limit used by OR-Tools.
+        solver.parameters.max_time_in_seconds = time_limit
+
+    progress = []
+
+    class _ProgressCollector(cp_model.CpSolverSolutionCallback):
+        def __init__(self, limit):
+            super().__init__()
+            self._count = 0
+            self._limit = limit
+
+        def OnSolutionCallback(self):
+            self._count += 1
+            msg = f"Solution {self._count}: score {self.ObjectiveValue():.1f} (higher is better)"
+            progress.append(msg)
+            if progress_callback:
+                progress_callback(msg)
+            # ``WallTime`` is measured in seconds and allows us to stop the
+            # search if the solver's internal limit fails for any reason.
+            if self._limit is not None and self.WallTime() >= self._limit:
+                self.StopSearch()
+
+    callback = _ProgressCollector(time_limit)
+
+    # Solve the model while tracking progress using the modern ``solve`` API.
+    status = solver.solve(model, callback)
 
     assignments = []
     if status in (cp_model.OPTIMAL, cp_model.FEASIBLE):
@@ -469,4 +488,4 @@ def solve_and_print(model, vars_, loc_vars, assumptions=None):
 
     # ``core`` gives a minimal set of unsatisfied assumption groups when no
     # feasible schedule exists.  ``assignments`` is empty in that case.
-    return status, assignments, core
+    return status, assignments, core, progress

--- a/templates/config.html
+++ b/templates/config.html
@@ -217,6 +217,9 @@
             <label class="block">Balance weight:
                 <input type="number" name="balance_weight" value="{{ config['balance_weight'] }}" min="1" class="border border-emerald-300 rounded-lg p-2.5 w-full">
             </label>
+            <label class="block">Solver time limit (seconds):
+                <input type="number" name="solver_time_limit" value="{{ config['solver_time_limit']|default(120, true) }}" min="1" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+            </label>
         </fieldset>
     </div>
     <!-- Subjects -->

--- a/tests/test_fixed_assignment_subject_id.py
+++ b/tests/test_fixed_assignment_subject_id.py
@@ -17,7 +17,8 @@ def test_fixed_assignment_handles_subject_id():
     model, vars_, loc_vars, _ = build_model(
         students, teachers, slots=1, min_lessons=0, max_lessons=1, fixed=fixed
     )
-    status, assignments, _ = solve_and_print(model, vars_, loc_vars)
+    status, assignments, _, progress = solve_and_print(model, vars_, loc_vars)
 
     # The fixed assignment should appear in the solver output
     assert (1, 1, 1, 0, None) in assignments
+    assert isinstance(progress, list)

--- a/tests/test_snapshot_lifecycle.py
+++ b/tests/test_snapshot_lifecycle.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import sqlite3
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+
+def setup_db(tmp_path):
+    import app
+    app.DB_PATH = str(tmp_path / 'test.db')
+    app.init_db()
+    conn = sqlite3.connect(app.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def test_generate_creates_snapshot(tmp_path):
+    import app
+    conn = setup_db(tmp_path)
+    conn.close()
+
+    client = app.app.test_client()
+    resp = client.post('/generate', data={'date': '2024-01-01', 'confirm': '1'}, follow_redirects=True)
+    assert resp.status_code == 200
+
+    conn = sqlite3.connect(app.DB_PATH)
+    row = conn.execute("SELECT 1 FROM timetable_snapshot WHERE date='2024-01-01'").fetchone()
+    conn.close()
+    assert row is not None
+
+
+def test_delete_timetables_removes_snapshot(tmp_path):
+    import app
+    conn = setup_db(tmp_path)
+    c = conn.cursor()
+    c.execute("INSERT INTO timetable (student_id, teacher_id, subject_id, slot, date) VALUES (1, 1, 1, 0, '2024-01-01')")
+    app.get_missing_and_counts(c, '2024-01-01', refresh=True)
+    conn.commit()
+    conn.close()
+
+    client = app.app.test_client()
+    resp = client.post('/delete_timetables', data={'dates': ['2024-01-01']}, follow_redirects=True)
+    assert resp.status_code == 200
+
+    conn = sqlite3.connect(app.DB_PATH)
+    row = conn.execute("SELECT 1 FROM timetable_snapshot WHERE date='2024-01-01'").fetchone()
+    conn.close()
+    assert row is None

--- a/tests/test_snapshot_lifecycle.py
+++ b/tests/test_snapshot_lifecycle.py
@@ -29,6 +29,24 @@ def test_generate_creates_snapshot(tmp_path):
     assert row is not None
 
 
+def test_regenerate_updates_snapshot(tmp_path):
+    import app
+    conn = setup_db(tmp_path)
+    conn.close()
+
+    client = app.app.test_client()
+    resp = client.post('/generate', data={'date': '2024-01-01', 'confirm': '1'}, follow_redirects=True)
+    assert resp.status_code == 200
+
+    resp = client.post('/generate', data={'date': '2024-01-01', 'confirm': '1'}, follow_redirects=True)
+    assert resp.status_code == 200
+
+    conn = sqlite3.connect(app.DB_PATH)
+    row = conn.execute("SELECT 1 FROM timetable_snapshot WHERE date='2024-01-01'").fetchone()
+    conn.close()
+    assert row is not None
+
+
 def test_delete_timetables_removes_snapshot(tmp_path):
     import app
     conn = setup_db(tmp_path)

--- a/tools/backfill_snapshots.py
+++ b/tools/backfill_snapshots.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import sqlite3
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, BASE_DIR)
+from app import DB_PATH, get_missing_and_counts
+
+
+def backfill():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    c = conn.cursor()
+
+    dates = [row['date'] for row in c.execute('SELECT DISTINCT date FROM timetable')]
+    created = 0
+    for d in dates:
+        c.execute('SELECT 1 FROM timetable_snapshot WHERE date=?', (d,))
+        if c.fetchone() is None:
+            get_missing_and_counts(c, d, refresh=True)
+            created += 1
+    conn.commit()
+    conn.close()
+    print(f"Created {created} snapshot(s).")
+
+
+if __name__ == '__main__':
+    backfill()

--- a/tools/cleanup_snapshots.py
+++ b/tools/cleanup_snapshots.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import json
+import sqlite3
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, BASE_DIR)
+from app import DB_PATH
+
+
+def cleanup():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    c = conn.cursor()
+
+    # Deduplicate rows by keeping the first row per date
+    c.execute(
+        """
+        DELETE FROM timetable_snapshot
+        WHERE rowid NOT IN (
+            SELECT MIN(rowid) FROM timetable_snapshot GROUP BY date
+        )
+        """
+    )
+
+    rows = c.execute("SELECT date, missing FROM timetable_snapshot").fetchall()
+    dates_to_delete = []
+    for row in rows:
+        missing = row["missing"]
+        if not missing:
+            continue
+        try:
+            data = json.loads(missing)
+        except json.JSONDecodeError:
+            dates_to_delete.append(row["date"])
+            continue
+        outdated = False
+        for subjects in data.values():
+            for entry in subjects:
+                if not isinstance(entry, dict) or "subject_id" not in entry:
+                    outdated = True
+                    break
+            if outdated:
+                break
+        if outdated:
+            dates_to_delete.append(row["date"])
+
+    if dates_to_delete:
+        c.executemany("DELETE FROM timetable_snapshot WHERE date = ?", [(d,) for d in dates_to_delete])
+
+    conn.commit()
+    print(f"Deduplicated and removed {len(dates_to_delete)} old snapshots")
+    conn.close()
+
+
+if __name__ == "__main__":
+    cleanup()


### PR DESCRIPTION
## Summary
- add tools/cleanup_snapshots.py to deduplicate timetable_snapshot rows and drop entries missing subject IDs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5c6fc6e9c8322adad840f7e2af953