### PR TITLE
Add time limit and progress callback to solver

### DIFF
--- a/CODE_GUIDE.txt
+++ b/CODE_GUIDE.txt
@@ -43,7 +43,7 @@ This module isolates the OR-Tools logic from the web code. ``build_model`` const
 
 The function can also attach assumption indicators to major constraint groups. When enabled, these indicators help explain which group caused the model to be infeasible.
 
-``solve_and_print`` runs the solver, emitting progress messages for each improved solution. It returns the chosen assignments, any conflicting assumption groups, and the list of progress messages.
+``solve_and_print`` runs the solver, emitting progress messages for each feasible solution (higher scores indicate better timetables). It returns the chosen assignments, any conflicting assumption groups, and the list of progress messages.
 
 Static files and templates
 --------------------------

--- a/CODE_GUIDE.txt
+++ b/CODE_GUIDE.txt
@@ -43,7 +43,7 @@ This module isolates the OR-Tools logic from the web code. ``build_model`` const
 
 The function can also attach assumption indicators to major constraint groups. When enabled, these indicators help explain which group caused the model to be infeasible.
 
-``solve_and_print`` runs the solver and extracts the assignments that were set to ``True``. If the model was infeasible and assumptions were used, it returns the names of the conflicting groups.
+``solve_and_print`` runs the solver, emitting progress messages for each improved solution. It returns the chosen assignments, any conflicting assumption groups, and the list of progress messages.
 
 Static files and templates
 --------------------------

--- a/app.py
+++ b/app.py
@@ -1690,6 +1690,7 @@ def generate_schedule(target_date=None):
     max_lessons = cfg['max_lessons']
     teacher_min = cfg['teacher_min_lessons']
     teacher_max = cfg['teacher_max_lessons']
+    solver_time_limit = cfg['solver_time_limit']
 
     c.execute('SELECT * FROM teachers')
     teachers = c.fetchall()
@@ -1869,7 +1870,9 @@ def generate_schedule(target_date=None):
         student_multi_teacher=student_multi,
         locations=locations,
         location_restrict=loc_restrict)
-    status, assignments, core, _ = solve_and_print(model, vars_, loc_vars, assumptions)
+    status, assignments, core, _ = solve_and_print(
+        model, vars_, loc_vars, assumptions, time_limit=solver_time_limit
+    )
 
     # Insert solver results into DB
     if assignments:

--- a/app.py
+++ b/app.py
@@ -1869,7 +1869,7 @@ def generate_schedule(target_date=None):
         student_multi_teacher=student_multi,
         locations=locations,
         location_restrict=loc_restrict)
-    status, assignments, core = solve_and_print(model, vars_, loc_vars, assumptions)
+    status, assignments, core, _ = solve_and_print(model, vars_, loc_vars, assumptions)
 
     # Insert solver results into DB
     if assignments:

--- a/app.py
+++ b/app.py
@@ -1870,9 +1870,30 @@ def generate_schedule(target_date=None):
         student_multi_teacher=student_multi,
         locations=locations,
         location_restrict=loc_restrict)
-    status, assignments, core, _ = solve_and_print(
-        model, vars_, loc_vars, assumptions, time_limit=solver_time_limit
+
+    progress_messages = []
+
+    def progress_cb(msg):
+        progress_messages.append(msg)
+        app.logger.info(msg)
+
+    status, assignments, core, progress = solve_and_print(
+        model,
+        vars_,
+        loc_vars,
+        assumptions,
+        time_limit=solver_time_limit,
+        progress_callback=progress_cb,
     )
+
+    from ortools.sat.python import cp_model
+    if status == cp_model.OPTIMAL:
+        flash('Optimal timetable found.', 'success')
+    elif status == cp_model.FEASIBLE:
+        flash('Feasible timetable found before time limit.', 'info')
+
+    for msg in progress:
+        flash(msg, 'info')
 
     # Insert solver results into DB
     if assignments:
@@ -1911,7 +1932,6 @@ def generate_schedule(target_date=None):
             c.executemany('INSERT INTO attendance_log (student_id, student_name, subject_id, date) VALUES (?, ?, ?, ?)',
                           attendance_rows)
     else:
-        from ortools.sat.python import cp_model
         if status == cp_model.INFEASIBLE:
             # Map assumption literals from the unsat core to human readable
             # messages explaining why the model is infeasible.

--- a/cp_sat_timetable.py
+++ b/cp_sat_timetable.py
@@ -461,7 +461,7 @@ def solve_and_print(model, vars_, loc_vars, assumptions=None, time_limit=None, p
     callback = _ProgressCollector(time_limit)
 
     # Solve the model while tracking progress.
-    status = solver.solve(model, callback)
+    status = solver.SolveWithSolutionCallback(model, callback)
 
     assignments = []
     if status in (cp_model.OPTIMAL, cp_model.FEASIBLE):

--- a/cp_sat_timetable.py
+++ b/cp_sat_timetable.py
@@ -446,7 +446,7 @@ def solve_and_print(model, vars_, loc_vars, assumptions=None, time_limit=None, p
 
         def OnSolutionCallback(self):
             self._count += 1
-            msg = f"Solution {self._count} with objective {self.ObjectiveValue()}"
+            msg = f"Solution {self._count}: score {self.ObjectiveValue():.1f} (higher is better)"
             progress.append(msg)
             if progress_callback:
                 progress_callback(msg)

--- a/cp_sat_timetable.py
+++ b/cp_sat_timetable.py
@@ -460,8 +460,8 @@ def solve_and_print(model, vars_, loc_vars, assumptions=None, time_limit=None, p
 
     callback = _ProgressCollector(time_limit)
 
-    # Solve the model while tracking progress.
-    status = solver.SolveWithSolutionCallback(model, callback)
+    # Solve the model while tracking progress using the modern ``solve`` API.
+    status = solver.solve(model, callback)
 
     assignments = []
     if status in (cp_model.OPTIMAL, cp_model.FEASIBLE):

--- a/cp_sat_timetable.py
+++ b/cp_sat_timetable.py
@@ -433,11 +433,8 @@ def solve_and_print(model, vars_, loc_vars, assumptions=None, time_limit=None, p
     # Instantiate the solver and let it process the model.
     solver = cp_model.CpSolver()
     if time_limit is not None:
-        # ``max_time_in_seconds`` is the canonical wall time limit, but we also
-        # mirror it to ``max_deterministic_time`` to ensure the solver respects
-        # the limit even when deterministic time is used internally.
+        # ``max_time_in_seconds`` is the canonical wall time limit used by OR-Tools.
         solver.parameters.max_time_in_seconds = time_limit
-        solver.parameters.max_deterministic_time = time_limit
 
     progress = []
 

--- a/tests/test_fixed_assignment_subject_id.py
+++ b/tests/test_fixed_assignment_subject_id.py
@@ -17,7 +17,8 @@ def test_fixed_assignment_handles_subject_id():
     model, vars_, loc_vars, _ = build_model(
         students, teachers, slots=1, min_lessons=0, max_lessons=1, fixed=fixed
     )
-    status, assignments, _ = solve_and_print(model, vars_, loc_vars)
+    status, assignments, _, progress = solve_and_print(model, vars_, loc_vars)
 
     # The fixed assignment should appear in the solver output
     assert (1, 1, 1, 0, None) in assignments
+    assert isinstance(progress, list)


### PR DESCRIPTION
## Summary
- allow `solve_and_print` to accept an optional time limit and progress callback
- track intermediate CP-SAT solutions via `CpSolverSolutionCallback`
- expose progress messages and update tests accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c60c7a6c6883228bf2003325c7030a