### PR TITLE
Allow per-student subject repeat configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ prioritize consecutive placement over other constraints. Another checkbox lets
 you allow or forbid a student taking the same subject from different teachers.
 When this is disabled the repeat option must also remain off, effectively
 limiting each student/subject pair to a single lesson per timetable.
+Individual students can further restrict repeated lessons to specific subjects
+via their advanced settings. Leaving this selection empty allows repeats for
+any of the student's subjects.
 
 Another option lets you disable the rule that every student must attend at
 least one lesson for each of their subjects. When unchecked the solver may skip

--- a/app.py
+++ b/app.py
@@ -174,7 +174,8 @@ def init_db():
             max_repeats INTEGER,
             allow_consecutive INTEGER,
             prefer_consecutive INTEGER,
-            allow_multi_teacher INTEGER
+            allow_multi_teacher INTEGER,
+            repeat_subjects TEXT
         )''')
     else:
         if not column_exists('students', 'active'):
@@ -193,6 +194,8 @@ def init_db():
             c.execute('ALTER TABLE students ADD COLUMN prefer_consecutive INTEGER')
         if not column_exists('students', 'allow_multi_teacher'):
             c.execute('ALTER TABLE students ADD COLUMN allow_multi_teacher INTEGER')
+        if not column_exists('students', 'repeat_subjects'):
+            c.execute('ALTER TABLE students ADD COLUMN repeat_subjects TEXT')
 
     if not table_exists('students_archive'):
         c.execute('''CREATE TABLE students_archive (
@@ -1173,17 +1176,19 @@ def config():
                 allow_con = 1 if request.form.get(f'student_allow_consecutive_{sid}') else 0
                 prefer_con = 1 if request.form.get(f'student_prefer_consecutive_{sid}') else 0
                 allow_multi = 1 if request.form.get(f'student_multi_teacher_{sid}') else 0
+                rep_subs = [int(x) for x in request.form.getlist(f'student_repeat_subjects_{sid}')]
                 subj_json = json.dumps(subs)
                 min_val = int(smin) if smin else None
                 max_val = int(smax) if smax else None
                 max_rep_val = int(max_rep) if max_rep else None
+                rep_sub_json = json.dumps(rep_subs) if rep_subs else None
                 c.execute('''UPDATE students SET name=?, subjects=?, active=?,
                              min_lessons=?, max_lessons=?, allow_repeats=?,
                              max_repeats=?, allow_consecutive=?, prefer_consecutive=?,
-                             allow_multi_teacher=? WHERE id=?''',
+                             allow_multi_teacher=?, repeat_subjects=? WHERE id=?''',
                           (name, subj_json, active, min_val, max_val,
                            allow_rep, max_rep_val, allow_con, prefer_con,
-                           allow_multi, int(sid)))
+                           allow_multi, rep_sub_json, int(sid)))
                 slots = request.form.getlist(f'student_unavail_{sid}')
                 c.execute('DELETE FROM student_unavailable WHERE student_id=?', (int(sid),))
                 for sl in slots:
@@ -1214,16 +1219,18 @@ def config():
         new_allow_con = 1 if request.form.get('new_student_allow_consecutive') else 0
         new_prefer_con = 1 if request.form.get('new_student_prefer_consecutive') else 0
         new_allow_multi = 1 if request.form.get('new_student_multi_teacher') else 0
+        new_rep_subs = [int(x) for x in request.form.getlist('new_student_repeat_subjects')]
         if new_sname and new_ssubs:
             subj_json = json.dumps(new_ssubs)
             min_val = int(new_smin) if new_smin else None
             max_val = int(new_smax) if new_smax else None
             max_rep_val = int(new_max_rep) if new_max_rep else None
+            rep_sub_json = json.dumps(new_rep_subs) if new_rep_subs else None
             c.execute('''INSERT INTO students (name, subjects, active, min_lessons, max_lessons,
-                      allow_repeats, max_repeats, allow_consecutive, prefer_consecutive, allow_multi_teacher)
-                      VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?, ?)''',
+                      allow_repeats, max_repeats, allow_consecutive, prefer_consecutive, allow_multi_teacher, repeat_subjects)
+                      VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?)''',
                       (new_sname, subj_json, min_val, max_val, new_allow_rep,
-                       max_rep_val, new_allow_con, new_prefer_con, new_allow_multi))
+                       max_rep_val, new_allow_con, new_prefer_con, new_allow_multi, rep_sub_json))
             new_sid = c.lastrowid
             for sl in new_unav:
                 c.execute('INSERT INTO student_unavailable (student_id, slot) VALUES (?, ?)',
@@ -1547,6 +1554,7 @@ def config():
     # Build mappings of subject IDs for form selections
     teacher_map = {t['id']: json.loads(t['subjects']) for t in teacher_rows}
     student_map = {s['id']: json.loads(s['subjects']) for s in student_rows}
+    student_repeat_map = {s['id']: json.loads(s['repeat_subjects']) if s['repeat_subjects'] else [] for s in student_rows}
     teachers = [dict(t) for t in teacher_rows]
     students = [dict(s) for s in student_rows]
     groups = [dict(g) for g in group_rows]
@@ -1555,6 +1563,7 @@ def config():
         t['subjects'] = json.dumps([subj_map.get(i, str(i)) for i in teacher_map.get(t['id'], [])])
     for s in students:
         s['subjects'] = json.dumps([subj_map.get(i, str(i)) for i in student_map.get(s['id'], [])])
+        s['repeat_subjects'] = student_repeat_map.get(s['id'], [])
     for g in groups:
         g['subjects'] = json.dumps([subj_map.get(i, str(i)) for i in group_subj_map.get(g['id'], [])])
     c.execute('SELECT * FROM locations')
@@ -1796,6 +1805,7 @@ def generate_schedule(target_date=None):
             'max_repeats': s['max_repeats'] if s['max_repeats'] is not None else max_repeats,
             'allow_consecutive': bool(s['allow_consecutive']) if s['allow_consecutive'] is not None else allow_consecutive,
             'prefer_consecutive': bool(s['prefer_consecutive']) if s['prefer_consecutive'] is not None else prefer_consecutive,
+            'repeat_subjects': s['repeat_subjects'] if s['repeat_subjects'] else None,
         }
         student_multi[sid] = bool(s['allow_multi_teacher']) if s['allow_multi_teacher'] is not None else allow_multi_teacher
     # Build the CP-SAT model with assumption literals so that we can obtain

--- a/cp_sat_timetable.py
+++ b/cp_sat_timetable.py
@@ -67,7 +67,8 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
             the global student lesson limits.
         student_repeat: optional mapping ``student_id -> dict`` specifying
             repeat preferences (``allow_repeats``, ``max_repeats``,
-            ``allow_consecutive`` and ``prefer_consecutive``).
+            ``allow_consecutive``, ``prefer_consecutive`` and
+            ``repeat_subjects`` – a list of subjects eligible for repeats).
         student_unavailable: optional mapping ``student_id -> set(slots)`` of
             time slots where the student cannot attend lessons.
         student_multi_teacher: optional mapping ``student_id -> bool``
@@ -266,7 +267,10 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
         max_rep = cfg.get('max_repeats', max_repeats)
         allow_consec_s = cfg.get('allow_consecutive', allow_consecutive)
         prefer_consec_s = cfg.get('prefer_consecutive', prefer_consecutive)
+        repeat_subs = cfg.get('repeat_subjects')
         repeat_limit = max_rep if allow_rep else 1
+        if repeat_subs is not None and subj not in repeat_subs:
+            repeat_limit = 1
         vars_list = list(slot_map.values())
         ct = model.Add(sum(vars_list) <= repeat_limit)
         if add_assumptions:

--- a/templates/config.html
+++ b/templates/config.html
@@ -91,6 +91,7 @@
                 <li><strong>Teacher min/max lessons</strong>: Global defaults used when a teacher’s own Min/Max is left blank.</li>
                 <li><strong>Allow repeated lessons</strong>: If off, each (student, teacher, subject) can occur at most once.</li>
                 <li><strong>Max repeats</strong>: Upper limit when repeats are allowed (applies per student–teacher–subject).</li>
+                <li><strong>Repeatable subjects</strong>: Advanced student setting that restricts which subjects may repeat. Leave blank to allow repeats for all of a student's subjects.</li>
                 <li><strong>Allow consecutive repeats</strong>: If off, repeated lessons for the same triple cannot be in adjacent slots.</li>
                 <li><strong>Prefer consecutive repeats</strong>: Adds a bonus to schedule back‑to‑back repeats (only takes effect when consecutive is allowed).</li>
                 <li><strong>Allow different teachers per subject</strong>: If off, a student can study a subject with at most one teacher; repeats with that same teacher are still allowed.</li>
@@ -369,6 +370,15 @@
                             <label class="flex items-center gap-2">Allow repeated lessons?
                                 <input type="checkbox" name="student_allow_repeats_{{ s['id'] }}" {% if (s['allow_repeats'] if s['allow_repeats'] is not none else config['allow_repeats']) %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
                             </label>
+                            <label class="block">Repeatable subjects:
+                                <select multiple name="student_repeat_subjects_{{ s['id'] }}" {% if not (s['allow_repeats'] if s['allow_repeats'] is not none else config['allow_repeats']) %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                                    {% for sub in subjects %}
+                                        {% if sub['id'] in student_map[s['id']] %}
+                                            <option value="{{ sub['id'] }}" {% if sub['id'] in s['repeat_subjects'] %}selected{% endif %}>{{ sub['name'] }}</option>
+                                        {% endif %}
+                                    {% endfor %}
+                                </select>
+                            </label>
                             <label class="flex items-center gap-2">Allow different teachers per subject?
                                 <input type="checkbox" name="student_multi_teacher_{{ s['id'] }}" {% if (s['allow_multi_teacher'] if s['allow_multi_teacher'] is not none else config['allow_multi_teacher']) %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
                             </label>
@@ -437,6 +447,13 @@
                             </label>
                             <label class="flex items-center gap-2">Allow repeated lessons?
                                 <input type="checkbox" name="new_student_allow_repeats" {% if config['allow_repeats'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                            </label>
+                            <label class="block">Repeatable subjects:
+                                <select multiple name="new_student_repeat_subjects" {% if not config['allow_repeats'] %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                                    {% for sub in subjects %}
+                                        <option value="{{ sub['id'] }}">{{ sub['name'] }}</option>
+                                    {% endfor %}
+                                </select>
                             </label>
                             <label class="flex items-center gap-2">Allow different teachers per subject?
                                 <input type="checkbox" name="new_student_multi_teacher" {% if config['allow_multi_teacher'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">

--- a/templates/config.html
+++ b/templates/config.html
@@ -368,10 +368,10 @@
                                 <input type="number" name="student_max_{{ s['id'] }}" value="{{ s['max_lessons'] if s['max_lessons'] is not none else config['max_lessons'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
                             </label>
                             <label class="flex items-center gap-2">Allow repeated lessons?
-                                <input type="checkbox" name="student_allow_repeats_{{ s['id'] }}" {% if (s['allow_repeats'] if s['allow_repeats'] is not none else config['allow_repeats']) %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                                <input type="checkbox" name="student_allow_repeats_{{ s['id'] }}" data-repeat-target="student_repeat_subjects_{{ s['id'] }}" {% if (s['allow_repeats'] if s['allow_repeats'] is not none else config['allow_repeats']) %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
                             </label>
                             <label class="block">Repeatable subjects:
-                                <select multiple name="student_repeat_subjects_{{ s['id'] }}" {% if not (s['allow_repeats'] if s['allow_repeats'] is not none else config['allow_repeats']) %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                                <select id="student_repeat_subjects_{{ s['id'] }}" multiple name="student_repeat_subjects_{{ s['id'] }}" {% if not (s['allow_repeats'] if s['allow_repeats'] is not none else config['allow_repeats']) %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
                                     {% for sub in subjects %}
                                         {% if sub['id'] in student_map[s['id']] %}
                                             <option value="{{ sub['id'] }}" {% if sub['id'] in s['repeat_subjects'] %}selected{% endif %}>{{ sub['name'] }}</option>
@@ -446,10 +446,10 @@
                                 <input type="number" name="new_student_max" value="{{ config['max_lessons'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
                             </label>
                             <label class="flex items-center gap-2">Allow repeated lessons?
-                                <input type="checkbox" name="new_student_allow_repeats" {% if config['allow_repeats'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                                <input type="checkbox" name="new_student_allow_repeats" data-repeat-target="new_student_repeat_subjects" {% if config['allow_repeats'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
                             </label>
                             <label class="block">Repeatable subjects:
-                                <select multiple name="new_student_repeat_subjects" {% if not config['allow_repeats'] %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                                <select id="new_student_repeat_subjects" multiple name="new_student_repeat_subjects" {% if not config['allow_repeats'] %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
                                     {% for sub in subjects %}
                                         <option value="{{ sub['id'] }}">{{ sub['name'] }}</option>
                                     {% endfor %}
@@ -682,6 +682,26 @@
         }
         return false;
     }
+
+    function bindRepeatToggle(toggle) {
+        const targetId = toggle.dataset.repeatTarget;
+        if (!targetId) {
+            return;
+        }
+        const select = document.getElementById(targetId);
+        if (!select) {
+            return;
+        }
+        const updateDisabledState = () => {
+            select.disabled = !toggle.checked;
+        };
+        toggle.addEventListener('change', updateDisabledState);
+        updateDisabledState();
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        document.querySelectorAll('[data-repeat-target]').forEach(bindRepeatToggle);
+    });
     </script>
     <script src="{{ url_for('static', filename='config.js') }}"></script>
     <script src="{{ url_for('static', filename='ui.js') }}"></script>

--- a/tests/test_student_repeat_subjects.py
+++ b/tests/test_student_repeat_subjects.py
@@ -1,0 +1,40 @@
+from ortools.sat.python import cp_model
+from cp_sat_timetable import build_model, solve_and_print
+import json
+
+
+def make_row(id_, subjects):
+    return {"id": id_, "subjects": json.dumps(subjects)}
+
+
+def test_repeat_allowed_only_for_selected_subjects():
+    students = [make_row(1, ["Math", "English"])]
+    teachers = [
+        {"id": 1, "subjects": json.dumps(["Math", "English"]), "min_lessons": 0, "max_lessons": None},
+    ]
+    slots = 3
+    student_limits = {1: (3, 3)}
+    student_repeat = {
+        1: {
+            "allow_repeats": True,
+            "max_repeats": 3,
+            "repeat_subjects": ["Math"],
+        }
+    }
+    model, vars_, loc_vars, assumptions = build_model(
+        students,
+        teachers,
+        slots,
+        min_lessons=3,
+        max_lessons=3,
+        allow_repeats=True,
+        max_repeats=3,
+        student_limits=student_limits,
+        student_repeat=student_repeat,
+        locations=[],
+    )
+    status, assignments, _, _ = solve_and_print(model, vars_, loc_vars, assumptions)
+    assert status in (cp_model.OPTIMAL, cp_model.FEASIBLE)
+    subjects = [subj for (_, _, subj, _, _) in assignments]
+    assert subjects.count("English") <= 1, "English should not be repeated"
+


### PR DESCRIPTION
## Summary
- allow selecting which subjects a student may repeat and store them in the database
- enforce subject-specific repeat limits in the solver
- document and test subject repeat selection

## Testing
- `pytest`
- `PYTHONPATH=. python tests/run_smoke_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68c8206034148322a596013c582d03fb