### PR TITLE
Add group data to timetable snapshots

### DIFF
--- a/tests/test_edit_timetable_worksheet.py
+++ b/tests/test_edit_timetable_worksheet.py
@@ -106,9 +106,10 @@ def test_refreshes_old_snapshot_without_subject_id(tmp_path):
     conn.row_factory = sqlite3.Row
     c = conn.cursor()
     row = c.execute(
-        'SELECT missing FROM timetable_snapshot WHERE date=?', ('2024-01-01',)
+        'SELECT missing, group_data FROM timetable_snapshot WHERE date=?', ('2024-01-01',)
     ).fetchone()
     data = json.loads(row['missing'])
+    assert row['group_data'] is not None
     assert 'subject_id' in data['1'][0]
     assert data['1'][0]['subject_id'] == math_id
     conn.close()

--- a/tests/test_location_display.py
+++ b/tests/test_location_display.py
@@ -27,7 +27,7 @@ def test_location_shown_in_timetable_grid(tmp_path):
     conn.commit()
     conn.close()
 
-    (_, _, teachers, grid, _, _, _, _, _) = app.get_timetable_data('2024-01-01')
+    (_, _, teachers, grid, _, _, _, _, _, _) = app.get_timetable_data('2024-01-01')
     # timetable entry for teacher 1 in slot 0 should include the location name
     assert 'Room A' in grid[0][teachers[0]['id']]
 
@@ -45,7 +45,7 @@ def test_location_view_groups_by_location(tmp_path):
     conn.commit()
     conn.close()
 
-    (_, _, locations, grid, _, _, _, _, _) = app.get_timetable_data('2024-01-01', view='location')
+    (_, _, locations, grid, _, _, _, _, _, _) = app.get_timetable_data('2024-01-01', view='location')
     assert locations[0]['name'] == 'Room A'
     assert grid[0][locations[0]['id']] == 'Student 1 (Math) with Teacher A'
 
@@ -63,5 +63,5 @@ def test_patient_only_view(tmp_path):
     conn.commit()
     conn.close()
 
-    (_, _, locations, grid, _, _, _, _, _) = app.get_timetable_data('2024-01-01', view='patient_only')
+    (_, _, locations, grid, _, _, _, _, _, _) = app.get_timetable_data('2024-01-01', view='patient_only')
     assert grid[0][locations[0]['id']] == 'Student 1'

--- a/tests/test_location_display.py
+++ b/tests/test_location_display.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 
@@ -65,3 +66,45 @@ def test_patient_only_view(tmp_path):
 
     (_, _, locations, grid, _, _, _, _, _, _) = app.get_timetable_data('2024-01-01', view='patient_only')
     assert grid[0][locations[0]['id']] == 'Student 1'
+
+
+def test_deleted_group_members_display_from_snapshot(tmp_path):
+    import app
+
+    conn = setup_db(tmp_path)
+    c = conn.cursor()
+
+    math_id = c.execute("SELECT id FROM subjects WHERE name='Math'").fetchone()[0]
+    teacher_id = c.execute("SELECT id FROM teachers WHERE name='Teacher A'").fetchone()[0]
+
+    c.execute("INSERT INTO groups (name, subjects) VALUES (?, ?)", ('Legacy Group', json.dumps([math_id])))
+    gid = c.lastrowid
+    c.executemany(
+        "INSERT INTO group_members (group_id, student_id) VALUES (?, ?)",
+        [(gid, 1), (gid, 2)],
+    )
+    c.execute(
+        "INSERT INTO timetable (student_id, group_id, teacher_id, subject_id, slot, location_id, date) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (None, gid, teacher_id, math_id, 0, None, '2024-01-01'),
+    )
+
+    app.get_missing_and_counts(c, '2024-01-01', refresh=True)
+    conn.commit()
+
+    c.execute('INSERT INTO groups_archive (id, name) VALUES (?, ?)', (gid, 'Legacy Group'))
+    c.execute('DELETE FROM group_members WHERE group_id=?', (gid,))
+    c.execute('DELETE FROM groups WHERE id=?', (gid,))
+    conn.commit()
+    conn.close()
+
+    (_, _, _, grid, _, _, _, _, _, group_view) = app.get_timetable_data('2024-01-01')
+    entry = grid[0][teacher_id]
+
+    assert 'Legacy Group' in entry
+    assert 'Student 1' in entry
+    assert 'Student 2' in entry
+    assert '[]' not in entry
+
+    members = group_view[gid]['members']
+    assert {m['name'] for m in members} >= {'Student 1', 'Student 2'}

--- a/tests/test_snapshot_lifecycle.py
+++ b/tests/test_snapshot_lifecycle.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import json
 import sqlite3
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
@@ -64,3 +65,36 @@ def test_delete_timetables_removes_snapshot(tmp_path):
     row = conn.execute("SELECT 1 FROM timetable_snapshot WHERE date='2024-01-01'").fetchone()
     conn.close()
     assert row is None
+
+
+def test_snapshot_records_group_members(tmp_path):
+    import app
+    conn = setup_db(tmp_path)
+    cur = conn.cursor()
+    math_id = cur.execute("SELECT id FROM subjects WHERE name='Math'").fetchone()[0]
+    cur.execute("INSERT INTO groups (name, subjects) VALUES (?, ?)", ('Group A', json.dumps([math_id])))
+    group_id = cur.lastrowid
+    cur.execute("INSERT INTO group_members (group_id, student_id) VALUES (?, ?)", (group_id, 1))
+    cur.execute("INSERT INTO group_members (group_id, student_id) VALUES (?, ?)", (group_id, 2))
+    cur.execute(
+        "INSERT INTO timetable (group_id, teacher_id, subject_id, slot, date) VALUES (?, ?, ?, 0, '2024-01-01')",
+        (group_id, 1, math_id),
+    )
+    app.get_missing_and_counts(cur, '2024-01-01', refresh=True)
+    conn.commit()
+    conn.close()
+
+    conn = sqlite3.connect(app.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute("SELECT group_data FROM timetable_snapshot WHERE date='2024-01-01'").fetchone()
+    conn.close()
+    assert row is not None
+    stored = json.loads(row['group_data'])
+    assert str(group_id) in stored
+    info = stored[str(group_id)]
+    assert info['name'] == 'Group A'
+    member_ids = {m['id'] for m in info['members']}
+    assert member_ids == {1, 2}
+    member_names = {m['name'] for m in info['members']}
+    assert 'Student 1' in member_names
+    assert 'Student 2' in member_names

--- a/tests/test_unassigned_inactive.py
+++ b/tests/test_unassigned_inactive.py
@@ -24,7 +24,7 @@ def test_inactive_student_listed_in_missing(tmp_path):
     conn.commit()
     conn.close()
 
-    _, _, _, _, missing, _, _, _, _ = app.get_timetable_data('2024-01-01')
+    _, _, _, _, missing, _, _, _, _, _ = app.get_timetable_data('2024-01-01')
     assert sid in missing
     subjects = {item['subject'] for item in missing[sid]}
     assert subjects == {'Math', 'English'}
@@ -53,7 +53,7 @@ def test_worksheet_counts_separate_by_id(tmp_path):
     conn.commit()
     conn.close()
 
-    _, _, _, _, missing, _, _, _, _ = app.get_timetable_data('2024-01-03')
+    _, _, _, _, missing, _, _, _, _, _ = app.get_timetable_data('2024-01-03')
     assert sid_new in missing
     math = next(item for item in missing[sid_new] if item['subject'] == 'Math')
     assert math['count'] == 0
@@ -100,7 +100,7 @@ def test_prior_lessons_included_in_counts(tmp_path):
     conn.close()
 
     # Now counts reflect worksheets only; a prior lesson does not increment worksheet count
-    _, _, _, _, missing, _, _, _, _ = app.get_timetable_data('2024-01-02')
+    _, _, _, _, missing, _, _, _, _, _ = app.get_timetable_data('2024-01-02')
     math = next(item for item in missing[sid] if item['subject'] == 'Math')
     assert math['count'] == 0
 
@@ -127,7 +127,7 @@ def test_deleted_student_preserved_in_missing(tmp_path):
     conn.commit()
     conn.close()
 
-    _, _, _, _, missing, _, _, _, _ = app.get_timetable_data('2024-01-01')
+    _, _, _, _, missing, _, _, _, _, _ = app.get_timetable_data('2024-01-01')
     assert sid in missing
     subjects = {item['subject'] for item in missing[sid]}
     assert subjects == {'English'}
@@ -159,7 +159,7 @@ def test_refresh_removes_deleted_student(tmp_path):
     resp = client.post('/edit_timetable/2024-01-01', data={'action': 'refresh'})
     assert resp.status_code == 302
 
-    _, _, _, _, missing, _, _, _, _ = app.get_timetable_data('2024-01-01')
+    _, _, _, _, missing, _, _, _, _, _ = app.get_timetable_data('2024-01-01')
     assert sid not in missing
 
 
@@ -186,11 +186,11 @@ def test_added_student_not_in_missing_until_refresh(tmp_path):
     app.init_db()
 
     # new student should not appear in existing missing list
-    _, _, _, _, missing, _, _, _, _ = app.get_timetable_data('2024-01-01')
+    _, _, _, _, missing, _, _, _, _, _ = app.get_timetable_data('2024-01-01')
     assert sid_new not in missing
 
     # after manual refresh the student is included
     client = app.app.test_client()
     client.post('/edit_timetable/2024-01-01', data={'action': 'refresh'})
-    _, _, _, _, missing2, _, _, _, _ = app.get_timetable_data('2024-01-01')
+    _, _, _, _, missing2, _, _, _, _, _ = app.get_timetable_data('2024-01-01')
     assert sid_new in missing2

--- a/tools/cleanup_snapshots.py
+++ b/tools/cleanup_snapshots.py
@@ -33,25 +33,51 @@ def cleanup():
     )
     removed_orphaned = c.rowcount
 
-    rows = c.execute("SELECT date, missing FROM timetable_snapshot").fetchall()
+    rows = c.execute("SELECT date, missing, group_data FROM timetable_snapshot").fetchall()
     dates_to_delete = []
     for row in rows:
         missing = row["missing"]
-        if not missing:
-            continue
-        try:
-            data = json.loads(missing)
-        except json.JSONDecodeError:
-            dates_to_delete.append(row["date"])
-            continue
         outdated = False
-        for subjects in data.values():
-            for entry in subjects:
-                if not isinstance(entry, dict) or "subject_id" not in entry:
+        if missing:
+            try:
+                data = json.loads(missing)
+            except json.JSONDecodeError:
+                outdated = True
+            else:
+                for subjects in data.values():
+                    for entry in subjects:
+                        if not isinstance(entry, dict) or "subject_id" not in entry:
+                            outdated = True
+                            break
+                    if outdated:
+                        break
+        group_raw = row["group_data"]
+        if not outdated:
+            if not group_raw:
+                outdated = True
+            else:
+                try:
+                    group_info = json.loads(group_raw)
+                except json.JSONDecodeError:
                     outdated = True
-                    break
-            if outdated:
-                break
+                else:
+                    if not isinstance(group_info, dict):
+                        outdated = True
+                    else:
+                        for info in group_info.values():
+                            if not isinstance(info, dict):
+                                outdated = True
+                                break
+                            members = info.get("members")
+                            if not isinstance(members, list):
+                                outdated = True
+                                break
+                            for member in members:
+                                if not isinstance(member, dict) or "id" not in member:
+                                    outdated = True
+                                    break
+                            if outdated:
+                                break
         if outdated:
             dates_to_delete.append(row["date"])
 


### PR DESCRIPTION
## Summary
- add a `group_data` column to timetable snapshots and backfill rows missing it during initialization
- capture group names and members whenever snapshot data is generated and surface the data to timetable views
- update snapshot cleanup tooling and tests to cover the new schema and behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c961673fb88322b32b75414d982823