### PR TITLE
Adjust config dropdown focus to emerald theme

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -31,8 +31,9 @@ input[type="time"]:focus,
 select:focus,
 textarea:focus,
 .emerald-focus:focus {
-    border-color: #10b981; /* emerald-500 */
-    box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.25);
+    border-color: #10b981 !important; /* emerald-500 */
+    box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.25) !important;
+    --tw-ring-color: rgba(16, 185, 129, 0.45) !important;
     outline: none;
 }
 


### PR DESCRIPTION
## Summary
- ensure custom emerald focus styling overrides Flowbite's blue ring on selects
- enforce emerald border, box shadow, and Tailwind ring color via !important flags

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cc5095d1f48322b70894f38a1f14fb