### PR TITLE
Improve assumption literals granularity

### DIFF
--- a/CODE_GUIDE.txt
+++ b/CODE_GUIDE.txt
@@ -43,7 +43,7 @@ This module isolates the OR-Tools logic from the web code. ``build_model`` const
 
 The function can also attach assumption indicators to major constraint groups. When enabled, these indicators help explain which group caused the model to be infeasible.
 
-``solve_and_print`` runs the solver, emitting progress messages for each feasible solution (higher scores indicate better timetables). It returns the chosen assignments, any conflicting assumption groups, and the list of progress messages.
+``solve_and_print`` runs the solver, emitting progress messages for each feasible solution (higher scores indicate better timetables). It returns the chosen assignments, structured metadata describing any conflicting assumption groups, and the list of progress messages.
 
 Static files and templates
 --------------------------

--- a/app.py
+++ b/app.py
@@ -2302,15 +2302,13 @@ def generate_schedule(target_date=None):
         if status == cp_model.INFEASIBLE:
             # Map assumption literals from the unsat core to human readable
             # messages explaining why the model is infeasible.
-            reason_map = {
-                'teacher_availability': 'A teacher is unavailable or blocked for a required lesson.',
-                'teacher_limits': 'Teacher lesson limits are too strict.',
-                'student_limits': 'Student lesson or subject requirements conflict.',
-                'repeat_restrictions': 'Repeat or consecutive lesson restrictions prevent a schedule.',
-            }
             flash('No feasible timetable could be generated.', 'error')
-            for name in core:
-                flash(reason_map.get(name, name), 'error')
+            if core:
+                for label in core:
+                    app.logger.error('Unsatisfied assumption: %s', label)
+                    flash(f'Conflict: {label}', 'error')
+            else:
+                app.logger.error('Solver reported infeasible without an unsat core.')
     conn.commit()
     conn.close()
 

--- a/tests/run_smoke_tests.py
+++ b/tests/run_smoke_tests.py
@@ -74,8 +74,11 @@ def test_unsat_core_present_on_conflict():
     status, assignments, core, progress = solve_and_print(model, vars_, loc_vars, assumptions)
     assert status == cp_model.INFEASIBLE, "Expected infeasible due to teacher unavailability and student min"
     assert core, "Expected an unsat core to be reported"
-    # Core likely includes teacher_availability and student_limits
-    assert any(k in core for k in ("teacher_availability", "student_limits")), f"Unexpected core: {core}"
+    # Core should include detailed identifiers for both the teacher and student
+    assert any("teacher_availability:" in label for label in core), f"Unexpected core: {core}"
+    assert any("teacher_id=1" in label for label in core), f"Teacher id missing in core: {core}"
+    assert any("student_limits:" in label for label in core), f"Unexpected core: {core}"
+    assert any("student_id=1" in label for label in core), f"Student id missing in core: {core}"
     assert progress == [], "No progress messages expected when infeasible"
 
 


### PR DESCRIPTION
## Summary
- break assumption indicators into per-entity literals in `build_model` and register descriptive labels for each
- map infeasible cores back to those detailed labels and expose them through the Flask UI logging/flash messaging
- extend the smoke test to assert that unsat cores include explicit teacher and student identifiers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd44b1e7408322b9953447c6149e17