### PR TITLE
Add assumption registry with granular unsat core context

### DIFF
--- a/tests/run_smoke_tests.py
+++ b/tests/run_smoke_tests.py
@@ -14,14 +14,14 @@ def test_no_locations_allows_schedule():
         {"id": 2, "subjects": json.dumps(["English"]), "min_lessons": 0, "max_lessons": None},
     ]
     slots = 2
-    model, vars_, loc_vars, assumptions = build_model(
+    model, vars_, loc_vars, registry = build_model(
         students, teachers, slots,
         min_lessons=0, max_lessons=2,
         unavailable=[], fixed=[],
         add_assumptions=True,
         locations=None,  # no locations configured
     )
-    status, assignments, core, progress = solve_and_print(model, vars_, loc_vars, assumptions)
+    status, assignments, core, progress = solve_and_print(model, vars_, loc_vars, registry)
     assert status in (cp_model.OPTIMAL, cp_model.FEASIBLE)
     assert len(assignments) > 0, "Expected some lessons to be scheduled without locations"
     assert progress, "Expected at least one progress message"
@@ -34,7 +34,7 @@ def test_multi_teacher_disallowed_allows_repeats_same_teacher():
         {"id": 2, "subjects": json.dumps(["Math"]), "min_lessons": 0, "max_lessons": None},
     ]
     slots = 2
-    model, vars_, loc_vars, assumptions = build_model(
+    model, vars_, loc_vars, registry = build_model(
         students, teachers, slots,
         min_lessons=2, max_lessons=2,
         allow_repeats=True, max_repeats=2,
@@ -44,7 +44,7 @@ def test_multi_teacher_disallowed_allows_repeats_same_teacher():
         student_limits={1: (2, 2)},
         locations=[],
     )
-    status, assignments, core, progress = solve_and_print(model, vars_, loc_vars, assumptions)
+    status, assignments, core, progress = solve_and_print(model, vars_, loc_vars, registry)
     assert status in (cp_model.OPTIMAL, cp_model.FEASIBLE)
     # Both slots scheduled, but with the same teacher id
     assigned = [(sid, tid, subj, sl) for (sid, tid, subj, sl, loc) in assignments]
@@ -62,7 +62,7 @@ def test_unsat_core_present_on_conflict():
     ]
     slots = 1
     unavailable = [{"teacher_id": 1, "slot": 0}]
-    model, vars_, loc_vars, assumptions = build_model(
+    model, vars_, loc_vars, registry = build_model(
         students, teachers, slots,
         min_lessons=1, max_lessons=1,
         allow_repeats=False,
@@ -71,11 +71,11 @@ def test_unsat_core_present_on_conflict():
         student_limits={1: (1, 1)},
         locations=[],
     )
-    status, assignments, core, progress = solve_and_print(model, vars_, loc_vars, assumptions)
+    status, assignments, core, progress = solve_and_print(model, vars_, loc_vars, registry)
     assert status == cp_model.INFEASIBLE, "Expected infeasible due to teacher unavailability and student min"
     assert core, "Expected an unsat core to be reported"
-    # Core likely includes teacher_availability and student_limits
-    assert any(k in core for k in ("teacher_availability", "student_limits")), f"Unexpected core: {core}"
+    # Core likely includes teacher availability and/or student limits information
+    assert any(info.kind in ("teacher_availability", "student_limits") for info in core), f"Unexpected core: {core}"
     assert progress == [], "No progress messages expected when infeasible"
 
 

--- a/tests/test_student_repeat_subjects.py
+++ b/tests/test_student_repeat_subjects.py
@@ -21,7 +21,7 @@ def test_repeat_allowed_only_for_selected_subjects():
             "repeat_subjects": ["Math"],
         }
     }
-    model, vars_, loc_vars, assumptions = build_model(
+    model, vars_, loc_vars, registry = build_model(
         students,
         teachers,
         slots,
@@ -33,7 +33,7 @@ def test_repeat_allowed_only_for_selected_subjects():
         student_repeat=student_repeat,
         locations=[],
     )
-    status, assignments, _, _ = solve_and_print(model, vars_, loc_vars, assumptions)
+    status, assignments, _, _ = solve_and_print(model, vars_, loc_vars, registry)
     assert status in (cp_model.OPTIMAL, cp_model.FEASIBLE)
     subjects = [subj for (_, _, subj, _, _) in assignments]
     assert subjects.count("English") <= 1, "English should not be repeated"


### PR DESCRIPTION
## Summary
- add an AssumptionRegistry that stores AssumptionInfo records for every constraint assumption
- guard teacher, student, repeat, and load constraints with contextual assumption literals and expose them from solve_and_print
- update the Flask app and tests to consume the registry and surface detailed unsat core information

## Testing
- pytest
- PYTHONPATH=. python tests/run_smoke_tests.py

------
https://chatgpt.com/codex/tasks/task_e_68ce4ceec1408322840f1b361b924639