### PR TITLE
Include group names in pseudo-students and extend smoke tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -2714,7 +2714,11 @@ def generate_schedule(target_date=None):
     # incorporate groups as pseudo students
     pseudo_students = []
     for g in groups:
-        ps = {"id": offset + g['id'], "subjects": g['subjects']}
+        ps = {
+            "id": offset + g['id'],
+            "subjects": g['subjects'],
+            "name": g['name'],
+        }
         pseudo_students.append(ps)
 
     actual_students = [dict(s) for s in students]

--- a/cp_sat_timetable.py
+++ b/cp_sat_timetable.py
@@ -99,7 +99,8 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
                 blocked=None, student_limits=None,
                 student_repeat=None, student_unavailable=None,
                 student_multi_teacher=None,
-                locations=None, location_restrict=None):
+                locations=None, location_restrict=None,
+                subject_lookup=None):
     """Build CP-SAT model for the scheduling problem.
 
     When ``add_assumptions`` is ``True``, Boolean indicators are created for the
@@ -156,6 +157,8 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
         locations: optional list of location identifiers.
         location_restrict: mapping ``student_id -> set(location_id)`` limiting
             the locations that may be used for that student or group.
+        subject_lookup: optional mapping ``subject_id -> display name`` used to
+            enrich assumption contexts with subject labels.
 
     Returns:
         model (cp_model.CpModel): The constructed model.
@@ -198,6 +201,7 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
 
     teacher_lookup = {t['id']: t for t in teachers}
     student_lookup = {s['id']: s for s in students}
+    subject_lookup = subject_lookup or {}
 
     # Map each group id to the subjects it requires and map each member student
     # to the subjects that must be taken through their group.  This helps filter
@@ -273,6 +277,7 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
                                 'teacher_id': teacher['id'],
                                 'teacher_name': _get_optional(teacher, 'name'),
                                 'subject': subject,
+                                'subject_name': subject_lookup.get(subject),
                                 'slot': slot,
                             },
                         )
@@ -294,6 +299,7 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
                                     'teacher_id': teacher['id'],
                                     'teacher_name': _get_optional(teacher, 'name'),
                                     'subject': subject,
+                                    'subject_name': subject_lookup.get(subject),
                                     'slot': slot,
                                     'reasons': reasons,
                                 },
@@ -331,6 +337,7 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
                         'teacher_id': tid,
                         'teacher_name': _get_optional(teacher_lookup.get(tid), 'name'),
                         'subject': subj,
+                        'subject_name': subject_lookup.get(subj),
                         'slot': sl,
                         'allowed_locations': [],
                     },
@@ -458,6 +465,7 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
                 'teacher_id': tid,
                 'teacher_name': _get_optional(teacher_info, 'name'),
                 'subject': subj,
+                'subject_name': subject_lookup.get(subj),
                 'repeat_limit': repeat_limit,
             },
         )
@@ -476,6 +484,7 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
                             'teacher_id': tid,
                             'teacher_name': _get_optional(teacher_info, 'name'),
                             'subject': subj,
+                            'subject_name': subject_lookup.get(subj),
                             'slot': s,
                             'reason': 'no_consecutive_repeats',
                         },
@@ -524,6 +533,7 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
                     'student_id': sid,
                     'student_name': _get_optional(student_lookup.get(sid), 'name'),
                     'subject': subj,
+                    'subject_name': subject_lookup.get(subj),
                     'teacher_ids': list(tmap.keys()),
                 },
             )
@@ -603,6 +613,7 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
                             'student_id': sid,
                             'student_name': _get_optional(student_lookup.get(sid), 'name'),
                             'subject': subject,
+                            'subject_name': subject_lookup.get(subject),
                             'required': True,
                             'candidate_lessons': len(subject_vars),
                         },

--- a/cp_sat_timetable.py
+++ b/cp_sat_timetable.py
@@ -100,7 +100,7 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
                 student_repeat=None, student_unavailable=None,
                 student_multi_teacher=None,
                 locations=None, location_restrict=None,
-                subject_lookup=None):
+                subject_lookup=None, slot_labels=None):
     """Build CP-SAT model for the scheduling problem.
 
     When ``add_assumptions`` is ``True``, Boolean indicators are created for the
@@ -202,6 +202,7 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
     teacher_lookup = {t['id']: t for t in teachers}
     student_lookup = {s['id']: s for s in students}
     subject_lookup = subject_lookup or {}
+    slot_labels = slot_labels or {}
 
     # Map each group id to the subjects it requires and map each member student
     # to the subjects that must be taken through their group.  This helps filter
@@ -279,6 +280,7 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
                                 'subject': subject,
                                 'subject_name': subject_lookup.get(subject),
                                 'slot': slot,
+                                'slot_label': slot_labels.get(slot),
                             },
                         )
                         if lit is not None:
@@ -301,6 +303,7 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
                                     'subject': subject,
                                     'subject_name': subject_lookup.get(subject),
                                     'slot': slot,
+                                    'slot_label': slot_labels.get(slot),
                                     'reasons': reasons,
                                 },
                             )
@@ -339,6 +342,7 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
                         'subject': subj,
                         'subject_name': subject_lookup.get(subj),
                         'slot': sl,
+                        'slot_label': slot_labels.get(sl),
                         'allowed_locations': [],
                     },
                 )
@@ -367,6 +371,7 @@ def build_model(students, teachers, slots, min_lessons, max_lessons,
                         'teacher_id': teacher['id'],
                         'teacher_name': _get_optional(teacher, 'name'),
                         'slot': slot,
+                        'slot_label': slot_labels.get(slot),
                         'candidate_lessons': len(possible),
                     },
                 )

--- a/tests/run_smoke_tests.py
+++ b/tests/run_smoke_tests.py
@@ -7,12 +7,15 @@ if str(ROOT) not in sys.path:
 
 from ortools.sat.python import cp_model
 from cp_sat_timetable import build_model, solve_and_print
-from app import summarize_unsat_core
+from app import summarize_unsat_core, _format_summary_details, UNSAT_REASON_MAP
 import json
 
 
-def make_row(id_, subjects):
-    return {"id": id_, "subjects": json.dumps(subjects)}
+def make_row(id_, subjects, name=None):
+    row = {"id": id_, "subjects": json.dumps(subjects)}
+    if name is not None:
+        row["name"] = name
+    return row
 
 
 def test_no_locations_allows_schedule():
@@ -98,11 +101,53 @@ def test_unsat_core_present_on_conflict():
     assert student_summary.get('candidate_lessons') == [1], f"Expected candidate lessons of 1; got {student_summary}"
 
 
+def test_group_unsat_message_includes_group_name():
+    group_offset = 10000
+    group_id = group_offset + 1
+    group_name = "Robotics Club"
+
+    students = [
+        make_row(1, ["Math"], name="Alice"),
+        make_row(group_id, ["Math"], name=group_name),
+    ]
+    teachers = [
+        {"id": 1, "subjects": json.dumps(["Math"]), "min_lessons": 0, "max_lessons": None},
+    ]
+    slots = 1
+    unavailable = [{"teacher_id": 1, "slot": 0}]
+    model, vars_, loc_vars, assumption_registry = build_model(
+        students, teachers, slots,
+        min_lessons=1, max_lessons=1,
+        allow_repeats=False,
+        unavailable=unavailable, fixed=[],
+        add_assumptions=True,
+        group_members={group_id: [1]},
+        student_limits={1: (1, 1)},
+        locations=[],
+    )
+    status, assignments, core, progress = solve_and_print(model, vars_, loc_vars, assumption_registry)
+    assert status == cp_model.INFEASIBLE, "Expected infeasible due to group requirements"
+    summaries = summarize_unsat_core(core)
+    aggregated_messages = []
+    for summary in summaries:
+        if summary.get('aggregated'):
+            kind = summary.get('kind')
+            base = UNSAT_REASON_MAP.get(kind, summary.get('label') or kind or 'Constraint conflict')
+            details = _format_summary_details(summary)
+            message = base
+            if details:
+                message = f"{base} ({'; '.join(details)})"
+            aggregated_messages.append(message)
+    combined = ' '.join(aggregated_messages)
+    assert group_name in combined, f"Expected group name in messages: {aggregated_messages}"
+
+
 def main():
     tests = [
         ("no_locations", test_no_locations_allows_schedule),
         ("multi_teacher_disallowed_repeats_same_teacher", test_multi_teacher_disallowed_allows_repeats_same_teacher),
         ("unsat_core", test_unsat_core_present_on_conflict),
+        ("group_unsat_message", test_group_unsat_message_includes_group_name),
     ]
     failures = []
     for name, fn in tests:

--- a/tests/run_smoke_tests.py
+++ b/tests/run_smoke_tests.py
@@ -101,6 +101,22 @@ def test_unsat_core_present_on_conflict():
     assert student_summary.get('candidate_lessons') == [1], f"Expected candidate lessons of 1; got {student_summary}"
 
 
+def test_capacity_summary_formats_slot_candidates_human_readable():
+    summary = {
+        'kind': 'teacher_availability',
+        'aggregated': True,
+        'category': 'capacity',
+        'teacher_id': 5,
+        'teacher_name': 'Ms. Wong',
+        'slots': [0],
+        'slot_candidates': {0: 21},
+        'slot_labels': {0: '08:30-09:00'},
+    }
+    details = _format_summary_details(summary)
+    combined = ' '.join(details)
+    assert 'slot 0 (08:30-09:00) has 21 candidate lessons' in combined, combined
+
+
 def test_group_unsat_message_includes_group_and_subject_names():
     group_offset = 10000
     group_id = group_offset + 1
@@ -151,6 +167,7 @@ def main():
         ("no_locations", test_no_locations_allows_schedule),
         ("multi_teacher_disallowed_repeats_same_teacher", test_multi_teacher_disallowed_allows_repeats_same_teacher),
         ("unsat_core", test_unsat_core_present_on_conflict),
+        ("capacity_summary_formatting", test_capacity_summary_formats_slot_candidates_human_readable),
         ("group_unsat_message", test_group_unsat_message_includes_group_and_subject_names),
     ]
     failures = []

--- a/tests/run_smoke_tests.py
+++ b/tests/run_smoke_tests.py
@@ -101,17 +101,19 @@ def test_unsat_core_present_on_conflict():
     assert student_summary.get('candidate_lessons') == [1], f"Expected candidate lessons of 1; got {student_summary}"
 
 
-def test_group_unsat_message_includes_group_name():
+def test_group_unsat_message_includes_group_and_subject_names():
     group_offset = 10000
     group_id = group_offset + 1
     group_name = "Robotics Club"
+    subject_id = 9
+    subject_name = "Robotics"
 
     students = [
-        make_row(1, ["Math"], name="Alice"),
-        make_row(group_id, ["Math"], name=group_name),
+        make_row(1, [subject_id], name="Alice"),
+        make_row(group_id, [subject_id], name=group_name),
     ]
     teachers = [
-        {"id": 1, "subjects": json.dumps(["Math"]), "min_lessons": 0, "max_lessons": None},
+        {"id": 1, "subjects": json.dumps([subject_id]), "min_lessons": 0, "max_lessons": None},
     ]
     slots = 1
     unavailable = [{"teacher_id": 1, "slot": 0}]
@@ -124,6 +126,7 @@ def test_group_unsat_message_includes_group_name():
         group_members={group_id: [1]},
         student_limits={1: (1, 1)},
         locations=[],
+        subject_lookup={subject_id: subject_name},
     )
     status, assignments, core, progress = solve_and_print(model, vars_, loc_vars, assumption_registry)
     assert status == cp_model.INFEASIBLE, "Expected infeasible due to group requirements"
@@ -140,6 +143,7 @@ def test_group_unsat_message_includes_group_name():
             aggregated_messages.append(message)
     combined = ' '.join(aggregated_messages)
     assert group_name in combined, f"Expected group name in messages: {aggregated_messages}"
+    assert subject_name in combined, f"Expected subject name in messages: {aggregated_messages}"
 
 
 def main():
@@ -147,7 +151,7 @@ def main():
         ("no_locations", test_no_locations_allows_schedule),
         ("multi_teacher_disallowed_repeats_same_teacher", test_multi_teacher_disallowed_allows_repeats_same_teacher),
         ("unsat_core", test_unsat_core_present_on_conflict),
-        ("group_unsat_message", test_group_unsat_message_includes_group_name),
+        ("group_unsat_message", test_group_unsat_message_includes_group_and_subject_names),
     ]
     failures = []
     for name, fn in tests:


### PR DESCRIPTION
## Summary
- add each group's name to the pseudo student records passed into the solver so diagnostics can display it
- extend the smoke tests to cover group infeasibility messaging and expose optional names in the helper

## Testing
- python tests/run_smoke_tests.py

------
https://chatgpt.com/codex/tasks/task_e_68ce627af48c83228822cc3a43d62a3f