### PR TITLE
Add cancel and save lifecycle to configuration modals

### DIFF
--- a/app.py
+++ b/app.py
@@ -1242,8 +1242,17 @@ def config():
     c = conn.cursor()
     if request.method == 'POST':
         has_error = False
-        slots_per_day = int(request.form['slots_per_day'])
-        slot_duration = int(request.form['slot_duration'])
+        try:
+            slots_per_day = int(request.form['slots_per_day'])
+            slot_duration = int(request.form['slot_duration'])
+        except (KeyError, TypeError, ValueError):
+            flash('Slots per day and slot duration must be positive integers.', 'error')
+            conn.close()
+            return redirect(url_for('config'))
+        if slots_per_day < 1 or slot_duration < 1:
+            flash('Slots per day and slot duration must be positive integers.', 'error')
+            conn.close()
+            return redirect(url_for('config'))
         start_times = []
         for i in range(1, slots_per_day + 1):
             val = request.form.get(f'slot_start_{i}')

--- a/app.py
+++ b/app.py
@@ -1353,10 +1353,6 @@ def config():
             if max_repeats < 2:
                 flash('Max repeats must be at least 2', 'error')
                 has_error = True
-        if not allow_multi_teacher and allow_repeats:
-            flash('Cannot allow repeats when different teachers per subject are disallowed.', 'error')
-            has_error = True
-
         c.execute("""UPDATE config SET slots_per_day=?, slot_duration=?, slot_start_times=?,
                      min_lessons=?, max_lessons=?, teacher_min_lessons=?, teacher_max_lessons=?,
                      allow_repeats=?, max_repeats=?,

--- a/app.py
+++ b/app.py
@@ -1310,11 +1310,29 @@ def config():
             flash('Global teacher maximum lessons cannot exceed slots per day.', 'error')
             conn.close()
             return redirect(url_for('config'))
-        allow_repeats = 1 if request.form.get('allow_repeats') else 0
-        max_repeats = int(request.form['max_repeats'])
-        prefer_consecutive = 1 if request.form.get('prefer_consecutive') else 0
-        allow_consecutive = 1 if request.form.get('allow_consecutive') else 0
-        consecutive_weight = int(request.form['consecutive_weight'])
+        repeat_defaults = c.execute(
+            'SELECT max_repeats, prefer_consecutive, allow_consecutive, consecutive_weight '
+            'FROM config WHERE id=1'
+        ).fetchone()
+        allow_repeats = 1 if 'allow_repeats' in request.form else 0
+        max_repeats_raw = request.form.get('max_repeats')
+        max_repeats_posted = max_repeats_raw is not None and max_repeats_raw.strip() != ''
+        if max_repeats_posted:
+            max_repeats = int(max_repeats_raw)
+        else:
+            max_repeats = repeat_defaults['max_repeats'] if repeat_defaults else 1
+        prefer_consecutive_posted = 'prefer_consecutive' in request.form
+        prefer_consecutive = 1 if prefer_consecutive_posted else 0
+        allow_consecutive_posted = 'allow_consecutive' in request.form
+        allow_consecutive = 1 if allow_consecutive_posted else 0
+        consecutive_weight_raw = request.form.get('consecutive_weight')
+        consecutive_weight_posted = (
+            consecutive_weight_raw is not None and consecutive_weight_raw.strip() != ''
+        )
+        if consecutive_weight_posted:
+            consecutive_weight = int(consecutive_weight_raw)
+        else:
+            consecutive_weight = repeat_defaults['consecutive_weight'] if repeat_defaults else 0
         require_all_subjects = 1 if request.form.get('require_all_subjects') else 0
         use_attendance_priority = 1 if request.form.get('use_attendance_priority') else 0
         attendance_weight = int(request.form['attendance_weight'])
@@ -1343,8 +1361,28 @@ def config():
             )
 
         if not allow_repeats:
-            allow_consecutive = 0
-            prefer_consecutive = 0
+            repeat_conflict = (
+                (max_repeats_posted and max_repeats > 1)
+                or allow_consecutive_posted
+                or prefer_consecutive_posted
+                or (consecutive_weight_posted and consecutive_weight != 0)
+            )
+            if repeat_conflict:
+                flash(
+                    'Repeated lesson settings require "Allow repeated lessons?" to be enabled.',
+                    'error'
+                )
+                has_error = True
+                if repeat_defaults:
+                    max_repeats = repeat_defaults['max_repeats']
+                    allow_consecutive = repeat_defaults['allow_consecutive']
+                    prefer_consecutive = repeat_defaults['prefer_consecutive']
+                    consecutive_weight = repeat_defaults['consecutive_weight']
+            else:
+                max_repeats = 1
+                allow_consecutive = 0
+                prefer_consecutive = 0
+                consecutive_weight = 0
         else:
             if not allow_consecutive and prefer_consecutive:
                 flash('Cannot prefer consecutive slots when consecutive repeats are disallowed.',

--- a/app.py
+++ b/app.py
@@ -1276,11 +1276,40 @@ def config():
             start_times.append(f"{h:02d}:{m:02d}")
         min_lessons = int(request.form['min_lessons'])
         max_lessons = int(request.form['max_lessons'])
+        if min_lessons < 0 or max_lessons < 0:
+            flash('Minimum and maximum lessons must be zero or greater.', 'error')
+            conn.close()
+            return redirect(url_for('config'))
+        if min_lessons > max_lessons:
+            flash('Minimum lessons cannot exceed maximum lessons.', 'error')
+            conn.close()
+            return redirect(url_for('config'))
+        if min_lessons > slots_per_day:
+            flash('Minimum lessons cannot exceed slots per day.', 'error')
+            conn.close()
+            return redirect(url_for('config'))
+        if max_lessons > slots_per_day:
+            flash('Maximum lessons cannot exceed slots per day.', 'error')
+            conn.close()
+            return redirect(url_for('config'))
         t_min_lessons = int(request.form['teacher_min_lessons'])
         t_max_lessons = int(request.form['teacher_max_lessons'])
+        if t_min_lessons < 0 or t_max_lessons < 0:
+            flash('Global teacher minimum and maximum lessons must be zero or greater.', 'error')
+            conn.close()
+            return redirect(url_for('config'))
         if t_min_lessons > t_max_lessons:
-            flash('Global teacher min lessons cannot exceed max lessons', 'error')
-            has_error = True
+            flash('Global teacher min lessons cannot exceed max lessons.', 'error')
+            conn.close()
+            return redirect(url_for('config'))
+        if t_min_lessons > slots_per_day:
+            flash('Global teacher minimum lessons cannot exceed slots per day.', 'error')
+            conn.close()
+            return redirect(url_for('config'))
+        if t_max_lessons > slots_per_day:
+            flash('Global teacher maximum lessons cannot exceed slots per day.', 'error')
+            conn.close()
+            return redirect(url_for('config'))
         allow_repeats = 1 if request.form.get('allow_repeats') else 0
         max_repeats = int(request.form['max_repeats'])
         prefer_consecutive = 1 if request.form.get('prefer_consecutive') else 0
@@ -1406,6 +1435,22 @@ def config():
                 tmax = request.form.get(f'teacher_max_{tid}')
                 min_val = int(tmin) if tmin else None
                 max_val = int(tmax) if tmax else None
+                if min_val is not None and min_val < 0:
+                    flash('Teacher minimum lessons must be zero or greater for ' + name + '.', 'error')
+                    has_error = True
+                    continue
+                if max_val is not None and max_val < 0:
+                    flash('Teacher maximum lessons must be zero or greater for ' + name + '.', 'error')
+                    has_error = True
+                    continue
+                if min_val is not None and min_val > slots_per_day:
+                    flash('Teacher minimum lessons cannot exceed slots per day for ' + name + '.', 'error')
+                    has_error = True
+                    continue
+                if max_val is not None and max_val > slots_per_day:
+                    flash('Teacher maximum lessons cannot exceed slots per day for ' + name + '.', 'error')
+                    has_error = True
+                    continue
                 if min_val is not None and max_val is not None and min_val > max_val:
                     flash('Teacher min lessons greater than max for ' + name, 'error')
                     has_error = True
@@ -1420,10 +1465,28 @@ def config():
             subj_json = json.dumps(new_tsubs)
             min_val = int(new_tmin) if new_tmin else None
             max_val = int(new_tmax) if new_tmax else None
+            invalid_teacher = False
+            if min_val is not None and min_val < 0:
+                flash('New teacher minimum lessons must be zero or greater.', 'error')
+                has_error = True
+                invalid_teacher = True
+            if max_val is not None and max_val < 0:
+                flash('New teacher maximum lessons must be zero or greater.', 'error')
+                has_error = True
+                invalid_teacher = True
+            if min_val is not None and min_val > slots_per_day:
+                flash('New teacher minimum lessons cannot exceed slots per day.', 'error')
+                has_error = True
+                invalid_teacher = True
+            if max_val is not None and max_val > slots_per_day:
+                flash('New teacher maximum lessons cannot exceed slots per day.', 'error')
+                has_error = True
+                invalid_teacher = True
             if min_val is not None and max_val is not None and min_val > max_val:
                 flash('New teacher min lessons greater than max', 'error')
                 has_error = True
-            else:
+                invalid_teacher = True
+            if not invalid_teacher:
                 c.execute('INSERT INTO teachers (name, subjects, min_lessons, max_lessons) VALUES (?, ?, ?, ?)',
                           (new_tname, subj_json, min_val, max_val))
 
@@ -1501,6 +1564,26 @@ def config():
                 max_val = int(smax) if smax else None
                 max_rep_val = int(max_rep) if max_rep else None
                 rep_sub_json = json.dumps(rep_subs) if rep_subs else None
+                if min_val is not None and min_val < 0:
+                    flash('Student minimum lessons must be zero or greater for ' + name + '.', 'error')
+                    has_error = True
+                    continue
+                if max_val is not None and max_val < 0:
+                    flash('Student maximum lessons must be zero or greater for ' + name + '.', 'error')
+                    has_error = True
+                    continue
+                if min_val is not None and min_val > slots_per_day:
+                    flash('Student minimum lessons cannot exceed slots per day for ' + name + '.', 'error')
+                    has_error = True
+                    continue
+                if max_val is not None and max_val > slots_per_day:
+                    flash('Student maximum lessons cannot exceed slots per day for ' + name + '.', 'error')
+                    has_error = True
+                    continue
+                if min_val is not None and max_val is not None and min_val > max_val:
+                    flash('Student min lessons greater than max for ' + name, 'error')
+                    has_error = True
+                    continue
                 c.execute('''UPDATE students SET name=?, subjects=?, active=?,
                              min_lessons=?, max_lessons=?, allow_repeats=?,
                              max_repeats=?, allow_consecutive=?, prefer_consecutive=?,
@@ -1545,30 +1628,52 @@ def config():
             max_val = int(new_smax) if new_smax else None
             max_rep_val = int(new_max_rep) if new_max_rep else None
             rep_sub_json = json.dumps(new_rep_subs) if new_rep_subs else None
-            c.execute('''INSERT INTO students (name, subjects, active, min_lessons, max_lessons,
-                      allow_repeats, max_repeats, allow_consecutive, prefer_consecutive, allow_multi_teacher, repeat_subjects)
-                      VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?)''',
-                      (new_sname, subj_json, min_val, max_val, new_allow_rep,
-                       max_rep_val, new_allow_con, new_prefer_con, new_allow_multi, rep_sub_json))
-            new_sid = c.lastrowid
-            for sl in new_unav:
-                c.execute('INSERT INTO student_unavailable (student_id, slot) VALUES (?, ?)',
-                          (new_sid, int(sl)))
-            block_map_current[new_sid] = set()
-            for tid in new_blocks:
-                tval = int(tid)
-                if not block_allowed(new_sid, tval, teacher_map_block, student_groups_block,
-                                       group_members_block, group_subj_map_block,
-                                       block_map_current, fixed_pairs):
-                    flash('Cannot block selected teacher for student', 'error')
-                    has_error = True
-                    continue
-                c.execute('INSERT INTO student_teacher_block (student_id, teacher_id) VALUES (?, ?)',
-                          (new_sid, tval))
-                block_map_current.setdefault(new_sid, set()).add(tval)
-            for lid in request.form.getlist('new_student_locs'):
-                c.execute('INSERT INTO student_locations (student_id, location_id) VALUES (?, ?)',
-                          (new_sid, int(lid)))
+            invalid_student = False
+            if min_val is not None and min_val < 0:
+                flash('New student minimum lessons must be zero or greater.', 'error')
+                has_error = True
+                invalid_student = True
+            if max_val is not None and max_val < 0:
+                flash('New student maximum lessons must be zero or greater.', 'error')
+                has_error = True
+                invalid_student = True
+            if min_val is not None and min_val > slots_per_day:
+                flash('New student minimum lessons cannot exceed slots per day.', 'error')
+                has_error = True
+                invalid_student = True
+            if max_val is not None and max_val > slots_per_day:
+                flash('New student maximum lessons cannot exceed slots per day.', 'error')
+                has_error = True
+                invalid_student = True
+            if min_val is not None and max_val is not None and min_val > max_val:
+                flash('New student min lessons greater than max.', 'error')
+                has_error = True
+                invalid_student = True
+            if not invalid_student:
+                c.execute('''INSERT INTO students (name, subjects, active, min_lessons, max_lessons,
+                          allow_repeats, max_repeats, allow_consecutive, prefer_consecutive, allow_multi_teacher, repeat_subjects)
+                          VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?)''',
+                          (new_sname, subj_json, min_val, max_val, new_allow_rep,
+                           max_rep_val, new_allow_con, new_prefer_con, new_allow_multi, rep_sub_json))
+                new_sid = c.lastrowid
+                for sl in new_unav:
+                    c.execute('INSERT INTO student_unavailable (student_id, slot) VALUES (?, ?)',
+                              (new_sid, int(sl)))
+                block_map_current[new_sid] = set()
+                for tid in new_blocks:
+                    tval = int(tid)
+                    if not block_allowed(new_sid, tval, teacher_map_block, student_groups_block,
+                                           group_members_block, group_subj_map_block,
+                                           block_map_current, fixed_pairs):
+                        flash('Cannot block selected teacher for student', 'error')
+                        has_error = True
+                        continue
+                    c.execute('INSERT INTO student_teacher_block (student_id, teacher_id) VALUES (?, ?)',
+                              (new_sid, tval))
+                    block_map_current.setdefault(new_sid, set()).add(tval)
+                for lid in request.form.getlist('new_student_locs'):
+                    c.execute('INSERT INTO student_locations (student_id, location_id) VALUES (?, ?)',
+                              (new_sid, int(lid)))
 
         # Build helper maps used when validating group changes. These maps
         # describe which teachers can teach each subject, what subjects every

--- a/static/config.js
+++ b/static/config.js
@@ -56,6 +56,92 @@ document.addEventListener('DOMContentLoaded', function () {
     const slotTimesContainer = document.getElementById('slot-times');
     const slotsInput = document.querySelector('input[name="slots_per_day"]');
     const slotDurationInput = document.querySelector('input[name="slot_duration"]');
+    const configForm = document.getElementById('config-form');
+
+    if (configForm) {
+        const selects = configForm.querySelectorAll('select:not([multiple])');
+        selects.forEach(sel => {
+            sel.addEventListener('keydown', function (e) {
+                if (e.key === 'Enter') {
+                    configForm.submit();
+                }
+            });
+        });
+    }
+
+    const modalOriginalValues = new Map();
+
+    function captureModalState(modal) {
+        return Array.from(modal.querySelectorAll('input, select, textarea')).map(field => {
+            if (field.tagName === 'SELECT' && field.multiple) {
+                return {
+                    field,
+                    type: 'multiple',
+                    values: Array.from(field.options).filter(opt => opt.selected).map(opt => opt.value)
+                };
+            }
+            if (field.type === 'checkbox' || field.type === 'radio') {
+                return { field, type: 'checked', checked: field.checked };
+            }
+            return { field, type: 'value', value: field.value };
+        });
+    }
+
+    function restoreModalState(state) {
+        state.forEach(item => {
+            if (!item || !item.field) return;
+            if (item.type === 'multiple') {
+                const values = new Set(item.values || []);
+                Array.from(item.field.options).forEach(opt => {
+                    opt.selected = values.has(opt.value);
+                });
+            } else if (item.type === 'checked') {
+                item.field.checked = !!item.checked;
+            } else {
+                item.field.value = item.value;
+            }
+        });
+    }
+
+    const modalToggles = document.querySelectorAll('[data-modal-toggle]');
+    modalToggles.forEach(btn => {
+        btn.addEventListener('click', () => {
+            const targetId = btn.getAttribute('data-modal-target');
+            if (!targetId) return;
+            const modal = document.getElementById(targetId);
+            if (!modal) return;
+            if (modal.classList.contains('hidden')) {
+                modalOriginalValues.set(targetId, captureModalState(modal));
+            }
+        });
+    });
+
+    const modalCancelButtons = document.querySelectorAll('[data-modal-cancel]');
+    modalCancelButtons.forEach(btn => {
+        btn.addEventListener('click', () => {
+            const targetId = btn.getAttribute('data-modal-hide');
+            const modal = targetId ? document.getElementById(targetId) : btn.closest('[data-config-modal]');
+            if (!modal) return;
+            const state = modalOriginalValues.get(modal.id);
+            if (state) {
+                restoreModalState(state);
+                modalOriginalValues.delete(modal.id);
+            }
+        });
+    });
+
+    const modalSaveButtons = document.querySelectorAll('[data-modal-save]');
+    modalSaveButtons.forEach(btn => {
+        btn.addEventListener('click', () => {
+            if (configForm && typeof configForm.requestSubmit === 'function') {
+                const modal = btn.closest('[data-config-modal]');
+                if (modal) {
+                    modalOriginalValues.delete(modal.id);
+                }
+                configForm.requestSubmit();
+            }
+        });
+    });
 
     if (!teacherSelect || !studentSelect || !subjectSelect || !slotSelect) {
         return;
@@ -68,18 +154,6 @@ document.addEventListener('DOMContentLoaded', function () {
     const assignData = JSON.parse(document.getElementById('assign-data').textContent);
     const subjectMap = JSON.parse(document.getElementById('subject-map').textContent);
     const totalSlots = parseInt(slotSelect.dataset.totalSlots, 10);
-
-    const configForm = document.querySelector('form[method="post"]:not([action])');
-    if (configForm) {
-        const selects = configForm.querySelectorAll('select:not([multiple])');
-        selects.forEach(sel => {
-            sel.addEventListener('keydown', function (e) {
-                if (e.key === 'Enter') {
-                    configForm.submit();
-                }
-            });
-        });
-    }
 
     // Convert "HH:MM" to minutes.
     function parseTime(str) {

--- a/static/style.css
+++ b/static/style.css
@@ -29,3 +29,40 @@ td, th {
     padding: 0 4px;
 }
 
+/* Configuration page sticky action bar */
+.config-form {
+    padding-bottom: 6rem;
+}
+
+.sticky-action-bar {
+    position: sticky;
+    bottom: 0;
+    z-index: 20;
+    background-color: #ECFDF5; /* emerald-50 */
+    border-top: 1px solid #6EE7B7; /* emerald-300 */
+    box-shadow: 0 -4px 12px rgba(16, 185, 129, 0.15);
+    padding: 1rem 1.5rem;
+    margin: 0 -1.5rem;
+}
+
+.sticky-action-bar a,
+.sticky-action-bar button {
+    font-weight: 600;
+}
+
+@media (max-width: 768px) {
+    .config-form {
+        padding-bottom: 8rem;
+    }
+
+    .sticky-action-bar {
+        padding: 0.75rem 1rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .sticky-action-bar {
+        padding: 0.75rem 0.75rem;
+    }
+}
+

--- a/templates/config.html
+++ b/templates/config.html
@@ -69,7 +69,7 @@
         </form>
     </div>
 
-<form id="config-form" method="post" class="space-y-6">
+<form id="config-form" method="post" class="space-y-6 config-form">
 <div id="config-accordion" data-accordion="open" data-active-classes="bg-emerald-300" data-inactive-classes="text-grey-900" class="mb-4">
     <!-- Help & Guidance -->
     <h2 id="heading-help">
@@ -660,7 +660,13 @@
         </fieldset>
     </div>
 </div>
-        <button type="submit" class="w-full bg-emerald-500 text-white border rounded-md px-3 py-2 hover:bg-emerald-600 transition">Save</button>
+        <div class="sticky-action-bar flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
+            <a href="{{ url_for('index') }}" class="inline-flex w-full sm:w-auto justify-center bg-white text-emerald-700 border border-emerald-300 rounded-md px-3 py-2 hover:bg-emerald-100 transition">Cancel</a>
+            <div class="flex flex-col w-full sm:w-auto items-stretch sm:items-end gap-1">
+                <button type="submit" data-config-save title="Click Save or press Ctrl+Enter" class="w-full sm:w-auto bg-emerald-500 text-white border border-emerald-500 rounded-md px-3 py-2 hover:bg-emerald-600 transition">Save</button>
+                <p class="text-xs text-emerald-700 text-center sm:text-right">Shortcut: <kbd>Ctrl</kbd> + <kbd>Enter</kbd></p>
+            </div>
+        </div>
     </form>
 
     <form method="post" action="{{ url_for('reset_db') }}" id="reset-db-form" class="mt-4">

--- a/templates/config.html
+++ b/templates/config.html
@@ -23,6 +23,9 @@
         border-top-left-radius: 0;
         border-top-right-radius: 0;
     }
+    .repeat-control.repeat-disabled {
+        opacity: 0.6;
+    }
     </style>
 </head>
 <body class="bg-emerald-50 min-h-screen">
@@ -177,23 +180,23 @@
             <label class="block">Max lessons per teacher:
                 <input type="number" name="teacher_max_lessons" value="{{ config['teacher_max_lessons'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
             </label>
-            <label class="flex items-center gap-2">Allow repeated lessons?
-                <input type="checkbox" name="allow_repeats" {% if config['allow_repeats'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+            <label class="flex items-center gap-2" for="allow_repeats">Allow repeated lessons?
+                <input id="allow_repeats" type="checkbox" name="allow_repeats" data-repeat-target="max_repeats allow_consecutive prefer_consecutive consecutive_weight" {% if config['allow_repeats'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
             </label>
             <label class="flex items-center gap-2">Allow different teachers per subject?
                 <input type="checkbox" name="allow_multi_teacher" {% if config['allow_multi_teacher'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
             </label>
-            <label class="block">Max repeats per teacher/subject:
-                <input type="number" name="max_repeats" value="{{ config['max_repeats'] }}" min="1" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+            <label class="block repeat-control {% if not config['allow_repeats'] %}repeat-disabled{% endif %}" for="max_repeats">Max repeats per teacher/subject:
+                <input id="max_repeats" type="number" name="max_repeats" value="{{ config['max_repeats'] }}" min="1" {% if not config['allow_repeats'] %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
             </label>
-            <label class="flex items-center gap-2">Allow consecutive repeat slots?
-                <input type="checkbox" name="allow_consecutive" {% if config['allow_consecutive'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+            <label class="flex items-center gap-2 repeat-control {% if not config['allow_repeats'] %}repeat-disabled{% endif %}" for="allow_consecutive">Allow consecutive repeat slots?
+                <input id="allow_consecutive" type="checkbox" name="allow_consecutive" {% if config['allow_consecutive'] %}checked{% endif %} {% if not config['allow_repeats'] %}disabled{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
             </label>
-            <label class="flex items-center gap-2">Prefer consecutive repeats?
-                <input type="checkbox" name="prefer_consecutive" {% if config['prefer_consecutive'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+            <label class="flex items-center gap-2 repeat-control {% if not config['allow_repeats'] %}repeat-disabled{% endif %}" for="prefer_consecutive">Prefer consecutive repeats?
+                <input id="prefer_consecutive" type="checkbox" name="prefer_consecutive" {% if config['prefer_consecutive'] %}checked{% endif %} {% if not config['allow_repeats'] %}disabled{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
             </label>
-            <label class="block">Consecutive preference weight:
-                <input type="number" name="consecutive_weight" value="{{ config['consecutive_weight'] }}" min="1" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+            <label class="block repeat-control {% if not config['allow_repeats'] %}repeat-disabled{% endif %}" for="consecutive_weight">Consecutive preference weight:
+                <input id="consecutive_weight" type="number" name="consecutive_weight" value="{{ config['consecutive_weight'] }}" min="1" {% if not config['allow_repeats'] %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
             </label>
             <label class="flex items-center gap-2">Require all subjects?
                 <input type="checkbox" name="require_all_subjects" {% if config['require_all_subjects'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
@@ -352,6 +355,7 @@
                     <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
                         <div class="p-4">
                             <h3 class="text-lg mb-2">Advanced settings for {{ s['name'] }}</h3>
+                            {% set student_allow_repeats = s['allow_repeats'] if s['allow_repeats'] is not none else config['allow_repeats'] %}
                             <label class="block">Blocked Slots:
                                 <select multiple name="student_unavail_{{ s['id'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
                                     {% for i in range(config['slots_per_day']) %}
@@ -366,10 +370,10 @@
                                 <input type="number" name="student_max_{{ s['id'] }}" value="{{ s['max_lessons'] if s['max_lessons'] is not none else config['max_lessons'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
                             </label>
                             <label class="flex items-center gap-2">Allow repeated lessons?
-                                <input type="checkbox" name="student_allow_repeats_{{ s['id'] }}" data-repeat-target="student_repeat_subjects_{{ s['id'] }}" {% if (s['allow_repeats'] if s['allow_repeats'] is not none else config['allow_repeats']) %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                                <input type="checkbox" name="student_allow_repeats_{{ s['id'] }}" data-repeat-target="student_repeat_subjects_{{ s['id'] }} student_max_repeats_{{ s['id'] }} student_allow_consecutive_{{ s['id'] }} student_prefer_consecutive_{{ s['id'] }}" {% if student_allow_repeats %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
                             </label>
-                            <label class="block">Repeatable subjects:
-                                <select id="student_repeat_subjects_{{ s['id'] }}" multiple name="student_repeat_subjects_{{ s['id'] }}" {% if not (s['allow_repeats'] if s['allow_repeats'] is not none else config['allow_repeats']) %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                            <label class="block repeat-control {% if not student_allow_repeats %}repeat-disabled{% endif %}">Repeatable subjects:
+                                <select id="student_repeat_subjects_{{ s['id'] }}" multiple name="student_repeat_subjects_{{ s['id'] }}" {% if not student_allow_repeats %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
                                     {% for sub in subjects %}
                                         {% if sub['id'] in student_map[s['id']] %}
                                             <option value="{{ sub['id'] }}" {% if sub['id'] in s['repeat_subjects'] %}selected{% endif %}>{{ sub['name'] }}</option>
@@ -380,15 +384,21 @@
                             <label class="flex items-center gap-2">Allow different teachers per subject?
                                 <input type="checkbox" name="student_multi_teacher_{{ s['id'] }}" {% if (s['allow_multi_teacher'] if s['allow_multi_teacher'] is not none else config['allow_multi_teacher']) %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
                             </label>
-                            <label class="block">Max repeats:
-                                <input type="number" name="student_max_repeats_{{ s['id'] }}" value="{{ s['max_repeats'] if s['max_repeats'] is not none else config['max_repeats'] }}" min="1" class="border border-emerald-300 rounded-lg p-2.5 w-full">
-                            </label>
-                            <label class="flex items-center gap-2">Allow consecutive repeats?
-                                <input type="checkbox" name="student_allow_consecutive_{{ s['id'] }}" {% if (s['allow_consecutive'] if s['allow_consecutive'] is not none else config['allow_consecutive']) %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
-                            </label>
-                            <label class="flex items-center gap-2">Prefer consecutive repeats?
-                                <input type="checkbox" name="student_prefer_consecutive_{{ s['id'] }}" {% if (s['prefer_consecutive'] if s['prefer_consecutive'] is not none else config['prefer_consecutive']) %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
-                            </label>
+                            <div class="repeat-control {% if not student_allow_repeats %}repeat-disabled{% endif %}">
+                                <label class="block" for="student_max_repeats_{{ s['id'] }}">Max repeats:
+                                    <input id="student_max_repeats_{{ s['id'] }}" type="number" name="student_max_repeats_{{ s['id'] }}" value="{{ s['max_repeats'] if s['max_repeats'] is not none else config['max_repeats'] }}" min="1" {% if not student_allow_repeats %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                                </label>
+                            </div>
+                            <div class="repeat-control {% if not student_allow_repeats %}repeat-disabled{% endif %}">
+                                <label class="flex items-center gap-2" for="student_allow_consecutive_{{ s['id'] }}">Allow consecutive repeats?
+                                    <input id="student_allow_consecutive_{{ s['id'] }}" type="checkbox" name="student_allow_consecutive_{{ s['id'] }}" {% if (s['allow_consecutive'] if s['allow_consecutive'] is not none else config['allow_consecutive']) %}checked{% endif %} {% if not student_allow_repeats %}disabled{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                                </label>
+                            </div>
+                            <div class="repeat-control {% if not student_allow_repeats %}repeat-disabled{% endif %}">
+                                <label class="flex items-center gap-2" for="student_prefer_consecutive_{{ s['id'] }}">Prefer consecutive repeats?
+                                    <input id="student_prefer_consecutive_{{ s['id'] }}" type="checkbox" name="student_prefer_consecutive_{{ s['id'] }}" {% if (s['prefer_consecutive'] if s['prefer_consecutive'] is not none else config['prefer_consecutive']) %}checked{% endif %} {% if not student_allow_repeats %}disabled{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                                </label>
+                            </div>
                             <div class="mt-4 flex justify-end gap-2">
                                 <button type="button" data-modal-hide="adv-{{ s['id'] }}" data-modal-cancel class="border border-emerald-300 text-emerald-700 px-3 py-1 rounded hover:bg-emerald-50">Cancel</button>
                                 <button type="button" data-modal-save class="bg-emerald-500 text-white px-3 py-1 rounded">Save changes</button>
@@ -431,6 +441,7 @@
                     <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
                         <div class="p-4">
                             <h3 class="text-lg mb-2">Advanced settings for new student</h3>
+                            {% set new_student_allow_repeats = config['allow_repeats'] %}
                             <label class="block">Blocked Slots:
                                 <select multiple name="new_student_unavail" class="border border-emerald-300 rounded-lg p-2.5 w-full">
                                     {% for i in range(config['slots_per_day']) %}
@@ -445,10 +456,10 @@
                                 <input type="number" name="new_student_max" value="{{ config['max_lessons'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
                             </label>
                             <label class="flex items-center gap-2">Allow repeated lessons?
-                                <input type="checkbox" name="new_student_allow_repeats" data-repeat-target="new_student_repeat_subjects" {% if config['allow_repeats'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                                <input type="checkbox" name="new_student_allow_repeats" data-repeat-target="new_student_repeat_subjects new_student_max_repeats new_student_allow_consecutive new_student_prefer_consecutive" {% if new_student_allow_repeats %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
                             </label>
-                            <label class="block">Repeatable subjects:
-                                <select id="new_student_repeat_subjects" multiple name="new_student_repeat_subjects" {% if not config['allow_repeats'] %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                            <label class="block repeat-control {% if not new_student_allow_repeats %}repeat-disabled{% endif %}">Repeatable subjects:
+                                <select id="new_student_repeat_subjects" multiple name="new_student_repeat_subjects" {% if not new_student_allow_repeats %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
                                     {% for sub in subjects %}
                                         <option value="{{ sub['id'] }}">{{ sub['name'] }}</option>
                                     {% endfor %}
@@ -457,15 +468,21 @@
                             <label class="flex items-center gap-2">Allow different teachers per subject?
                                 <input type="checkbox" name="new_student_multi_teacher" {% if config['allow_multi_teacher'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
                             </label>
-                            <label class="block">Max repeats:
-                                <input type="number" name="new_student_max_repeats" value="{{ config['max_repeats'] }}" min="1" class="border border-emerald-300 rounded-lg p-2.5 w-full">
-                            </label>
-                            <label class="flex items-center gap-2">Allow consecutive repeats?
-                                <input type="checkbox" name="new_student_allow_consecutive" {% if config['allow_consecutive'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
-                            </label>
-                            <label class="flex items-center gap-2">Prefer consecutive repeats?
-                                <input type="checkbox" name="new_student_prefer_consecutive" {% if config['prefer_consecutive'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
-                            </label>
+                            <div class="repeat-control {% if not new_student_allow_repeats %}repeat-disabled{% endif %}">
+                                <label class="block" for="new_student_max_repeats">Max repeats:
+                                    <input id="new_student_max_repeats" type="number" name="new_student_max_repeats" value="{{ config['max_repeats'] }}" min="1" {% if not new_student_allow_repeats %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                                </label>
+                            </div>
+                            <div class="repeat-control {% if not new_student_allow_repeats %}repeat-disabled{% endif %}">
+                                <label class="flex items-center gap-2" for="new_student_allow_consecutive">Allow consecutive repeats?
+                                    <input id="new_student_allow_consecutive" type="checkbox" name="new_student_allow_consecutive" {% if config['allow_consecutive'] %}checked{% endif %} {% if not new_student_allow_repeats %}disabled{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                                </label>
+                            </div>
+                            <div class="repeat-control {% if not new_student_allow_repeats %}repeat-disabled{% endif %}">
+                                <label class="flex items-center gap-2" for="new_student_prefer_consecutive">Prefer consecutive repeats?
+                                    <input id="new_student_prefer_consecutive" type="checkbox" name="new_student_prefer_consecutive" {% if config['prefer_consecutive'] %}checked{% endif %} {% if not new_student_allow_repeats %}disabled{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+                                </label>
+                            </div>
                             <div class="mt-4 flex justify-end gap-2">
                                 <button type="button" data-modal-hide="adv-new" data-modal-cancel class="border border-emerald-300 text-emerald-700 px-3 py-1 rounded hover:bg-emerald-50">Cancel</button>
                                 <button type="button" data-modal-save class="bg-emerald-500 text-white px-3 py-1 rounded">Save changes</button>
@@ -690,16 +707,28 @@
     }
 
     function bindRepeatToggle(toggle) {
-        const targetId = toggle.dataset.repeatTarget;
-        if (!targetId) {
-            return;
-        }
-        const select = document.getElementById(targetId);
-        if (!select) {
+        const targetAttr = toggle.dataset.repeatTarget || '';
+        const targets = targetAttr
+            .split(/\s+/)
+            .map(id => id && document.getElementById(id))
+            .filter(Boolean);
+        if (!targets.length) {
             return;
         }
         const updateDisabledState = () => {
-            select.disabled = !toggle.checked;
+            const disabled = !toggle.checked;
+            const wrappers = Array.from(new Set(
+                targets
+                    .map(target => target.closest('.repeat-control'))
+                    .filter(Boolean)
+            ));
+            targets.forEach(target => {
+                target.disabled = disabled;
+                target.classList.toggle('cursor-not-allowed', disabled);
+            });
+            wrappers.forEach(wrapper => {
+                wrapper.classList.toggle('repeat-disabled', disabled);
+            });
         };
         toggle.addEventListener('change', updateDisabledState);
         updateDisabledState();

--- a/templates/config.html
+++ b/templates/config.html
@@ -69,7 +69,7 @@
         </form>
     </div>
 
-<form method="post" class="space-y-6">
+<form id="config-form" method="post" class="space-y-6">
 <div id="config-accordion" data-accordion="open" data-active-classes="bg-emerald-300" data-inactive-classes="text-grey-900" class="mb-4">
     <!-- Help & Guidance -->
     <h2 id="heading-help">
@@ -347,7 +347,7 @@
                 </select>
             </label>
             <button type="button" data-modal-target="adv-{{ s['id'] }}" data-modal-toggle="adv-{{ s['id'] }}" class="bg-emerald-200 text-emerald-800 px-2 py-1 rounded">Advanced</button>
-            <div id="adv-{{ s['id'] }}" tabindex="-1" aria-hidden="true" class="hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-[calc(100%-1rem)] max-h-full">
+            <div id="adv-{{ s['id'] }}" tabindex="-1" aria-hidden="true" data-config-modal class="hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-[calc(100%-1rem)] max-h-full">
                 <div class="relative p-4 w-full max-w-md max-h-full">
                     <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
                         <div class="p-4">
@@ -389,8 +389,9 @@
                             <label class="flex items-center gap-2">Prefer consecutive repeats?
                                 <input type="checkbox" name="student_prefer_consecutive_{{ s['id'] }}" {% if (s['prefer_consecutive'] if s['prefer_consecutive'] is not none else config['prefer_consecutive']) %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
                             </label>
-                            <div class="mt-2 text-right">
-                                <button type="button" data-modal-hide="adv-{{ s['id'] }}" class="bg-emerald-500 text-white px-3 py-1 rounded">Close</button>
+                            <div class="mt-4 flex justify-end gap-2">
+                                <button type="button" data-modal-hide="adv-{{ s['id'] }}" data-modal-cancel class="border border-emerald-300 text-emerald-700 px-3 py-1 rounded hover:bg-emerald-50">Cancel</button>
+                                <button type="button" data-modal-save class="bg-emerald-500 text-white px-3 py-1 rounded">Save changes</button>
                             </div>
                         </div>
                     </div>
@@ -425,7 +426,7 @@
                 </select>
             </label>
             <button type="button" data-modal-target="adv-new" data-modal-toggle="adv-new" class="bg-emerald-200 text-emerald-800 px-2 py-1 rounded">Advanced</button>
-            <div id="adv-new" tabindex="-1" aria-hidden="true" class="hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-[calc(100%-1rem)] max-h-full">
+            <div id="adv-new" tabindex="-1" aria-hidden="true" data-config-modal class="hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-[calc(100%-1rem)] max-h-full">
                 <div class="relative p-4 w-full max-w-md max-h-full">
                     <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
                         <div class="p-4">
@@ -465,8 +466,9 @@
                             <label class="flex items-center gap-2">Prefer consecutive repeats?
                                 <input type="checkbox" name="new_student_prefer_consecutive" {% if config['prefer_consecutive'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
                             </label>
-                            <div class="mt-2 text-right">
-                                <button type="button" data-modal-hide="adv-new" class="bg-emerald-500 text-white px-3 py-1 rounded">Close</button>
+                            <div class="mt-4 flex justify-end gap-2">
+                                <button type="button" data-modal-hide="adv-new" data-modal-cancel class="border border-emerald-300 text-emerald-700 px-3 py-1 rounded hover:bg-emerald-50">Cancel</button>
+                                <button type="button" data-modal-save class="bg-emerald-500 text-white px-3 py-1 rounded">Save changes</button>
                             </div>
                         </div>
                     </div>

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,71 @@
+"""Regression tests for configuration validation logic."""
+
+import os
+import sys
+import sqlite3
+
+from flask import get_flashed_messages
+from werkzeug.datastructures import MultiDict
+
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+
+def setup_db(tmp_path):
+    import app
+
+    app.DB_PATH = str(tmp_path / 'test.db')
+    app.init_db()
+    conn = sqlite3.connect(app.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _config_values(db_path):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute('SELECT slots_per_day, slot_duration FROM config WHERE id=1').fetchone()
+    conn.close()
+    return row['slots_per_day'], row['slot_duration']
+
+
+def test_reject_zero_slots_per_day(tmp_path):
+    import app
+
+    conn = setup_db(tmp_path)
+    conn.close()
+    original = _config_values(app.DB_PATH)
+
+    data = MultiDict([
+        ('slots_per_day', '0'),
+        ('slot_duration', '30'),
+    ])
+
+    with app.app.test_request_context('/config', method='POST', data=data):
+        response = app.config()
+        flashes = get_flashed_messages(with_categories=True)
+
+    assert response.status_code == 302
+    assert ('error', 'Slots per day and slot duration must be positive integers.') in flashes
+    assert _config_values(app.DB_PATH) == original
+
+
+def test_reject_negative_slot_duration(tmp_path):
+    import app
+
+    conn = setup_db(tmp_path)
+    conn.close()
+    original = _config_values(app.DB_PATH)
+
+    data = MultiDict([
+        ('slots_per_day', '8'),
+        ('slot_duration', '-5'),
+    ])
+
+    with app.app.test_request_context('/config', method='POST', data=data):
+        response = app.config()
+        flashes = get_flashed_messages(with_categories=True)
+
+    assert response.status_code == 302
+    assert ('error', 'Slots per day and slot duration must be positive integers.') in flashes
+    assert _config_values(app.DB_PATH) == original

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,5 +1,6 @@
 """Regression tests for configuration validation logic."""
 
+import json
 import os
 import sys
 import sqlite3
@@ -21,12 +22,69 @@ def setup_db(tmp_path):
     return conn
 
 
-def _config_values(db_path):
+def _config_row(db_path):
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
-    row = conn.execute('SELECT slots_per_day, slot_duration FROM config WHERE id=1').fetchone()
+    row = conn.execute('SELECT * FROM config WHERE id=1').fetchone()
     conn.close()
-    return row['slots_per_day'], row['slot_duration']
+    return dict(row)
+
+
+def _valid_config_form(row):
+    slot_starts = json.loads(row['slot_start_times']) if row['slot_start_times'] else []
+    data = [
+        ('slots_per_day', str(row['slots_per_day'])),
+        ('slot_duration', str(row['slot_duration'])),
+    ]
+    for idx, start in enumerate(slot_starts, start=1):
+        data.append((f'slot_start_{idx}', start))
+    data.extend([
+        ('min_lessons', str(row['min_lessons'])),
+        ('max_lessons', str(row['max_lessons'])),
+        ('teacher_min_lessons', str(row['teacher_min_lessons'])),
+        ('teacher_max_lessons', str(row['teacher_max_lessons'])),
+        ('max_repeats', str(row['max_repeats'])),
+        ('consecutive_weight', str(row['consecutive_weight'])),
+        ('attendance_weight', str(row['attendance_weight'])),
+        ('group_weight', str(row['group_weight'])),
+        ('well_attend_weight', str(row['well_attend_weight'])),
+        ('balance_weight', str(row['balance_weight'])),
+        ('solver_time_limit', str(row['solver_time_limit'])),
+    ])
+    for flag in [
+        'allow_repeats',
+        'prefer_consecutive',
+        'allow_consecutive',
+        'require_all_subjects',
+        'use_attendance_priority',
+        'allow_multi_teacher',
+        'balance_teacher_load',
+    ]:
+        if row[flag]:
+            data.append((flag, '1'))
+    return MultiDict(data)
+
+
+def _teacher_edit_form(config_row, teacher_row):
+    data = _valid_config_form(config_row)
+    tid = teacher_row['id']
+    data.add('teacher_id', str(tid))
+    data.add(f'teacher_name_{tid}', teacher_row['name'])
+    for subj_id in json.loads(teacher_row['subjects']):
+        data.add(f'teacher_subjects_{tid}', str(subj_id))
+    return data
+
+
+def _student_edit_form(config_row, student_row):
+    data = _valid_config_form(config_row)
+    sid = student_row['id']
+    data.add('student_id', str(sid))
+    data.add(f'student_name_{sid}', student_row['name'])
+    for subj_id in json.loads(student_row['subjects']):
+        data.add(f'student_subjects_{sid}', str(subj_id))
+    if student_row['active']:
+        data.add(f'student_active_{sid}', '1')
+    return data
 
 
 def test_reject_zero_slots_per_day(tmp_path):
@@ -34,7 +92,7 @@ def test_reject_zero_slots_per_day(tmp_path):
 
     conn = setup_db(tmp_path)
     conn.close()
-    original = _config_values(app.DB_PATH)
+    original = _config_row(app.DB_PATH)
 
     data = MultiDict([
         ('slots_per_day', '0'),
@@ -47,7 +105,7 @@ def test_reject_zero_slots_per_day(tmp_path):
 
     assert response.status_code == 302
     assert ('error', 'Slots per day and slot duration must be positive integers.') in flashes
-    assert _config_values(app.DB_PATH) == original
+    assert _config_row(app.DB_PATH) == original
 
 
 def test_reject_negative_slot_duration(tmp_path):
@@ -55,7 +113,7 @@ def test_reject_negative_slot_duration(tmp_path):
 
     conn = setup_db(tmp_path)
     conn.close()
-    original = _config_values(app.DB_PATH)
+    original = _config_row(app.DB_PATH)
 
     data = MultiDict([
         ('slots_per_day', '8'),
@@ -68,4 +126,374 @@ def test_reject_negative_slot_duration(tmp_path):
 
     assert response.status_code == 302
     assert ('error', 'Slots per day and slot duration must be positive integers.') in flashes
-    assert _config_values(app.DB_PATH) == original
+    assert _config_row(app.DB_PATH) == original
+
+
+def test_reject_negative_min_lessons(tmp_path):
+    import app
+
+    conn = setup_db(tmp_path)
+    conn.close()
+    original = _config_row(app.DB_PATH)
+
+    data = _valid_config_form(original)
+    data.setlist('min_lessons', ['-1'])
+
+    with app.app.test_request_context('/config', method='POST', data=data):
+        response = app.config()
+        flashes = get_flashed_messages(with_categories=True)
+
+    assert response.status_code == 302
+    assert ('error', 'Minimum and maximum lessons must be zero or greater.') in flashes
+    assert _config_row(app.DB_PATH) == original
+
+
+def test_reject_negative_max_lessons(tmp_path):
+    import app
+
+    conn = setup_db(tmp_path)
+    conn.close()
+    original = _config_row(app.DB_PATH)
+
+    data = _valid_config_form(original)
+    data.setlist('max_lessons', ['-3'])
+
+    with app.app.test_request_context('/config', method='POST', data=data):
+        response = app.config()
+        flashes = get_flashed_messages(with_categories=True)
+
+    assert response.status_code == 302
+    assert ('error', 'Minimum and maximum lessons must be zero or greater.') in flashes
+    assert _config_row(app.DB_PATH) == original
+
+
+def test_reject_negative_teacher_lessons(tmp_path):
+    import app
+
+    conn = setup_db(tmp_path)
+    conn.close()
+    original = _config_row(app.DB_PATH)
+
+    data = _valid_config_form(original)
+    data.setlist('teacher_min_lessons', ['-1'])
+
+    with app.app.test_request_context('/config', method='POST', data=data):
+        response = app.config()
+        flashes = get_flashed_messages(with_categories=True)
+
+    assert response.status_code == 302
+    assert ('error', 'Global teacher minimum and maximum lessons must be zero or greater.') in flashes
+    assert _config_row(app.DB_PATH) == original
+
+
+def test_reject_min_lessons_greater_than_max(tmp_path):
+    import app
+
+    conn = setup_db(tmp_path)
+    conn.close()
+    original = _config_row(app.DB_PATH)
+
+    data = _valid_config_form(original)
+    data.setlist('min_lessons', [str(original['max_lessons'] + 1)])
+
+    with app.app.test_request_context('/config', method='POST', data=data):
+        response = app.config()
+        flashes = get_flashed_messages(with_categories=True)
+
+    assert response.status_code == 302
+    assert ('error', 'Minimum lessons cannot exceed maximum lessons.') in flashes
+    assert _config_row(app.DB_PATH) == original
+
+
+def test_reject_min_lessons_greater_than_slots(tmp_path):
+    import app
+
+    conn = setup_db(tmp_path)
+    conn.close()
+    original = _config_row(app.DB_PATH)
+
+    data = _valid_config_form(original)
+    slots = original['slots_per_day']
+    data.setlist('min_lessons', [str(slots + 1)])
+    data.setlist('max_lessons', [str(slots + 2)])
+
+    with app.app.test_request_context('/config', method='POST', data=data):
+        response = app.config()
+        flashes = get_flashed_messages(with_categories=True)
+
+    assert response.status_code == 302
+    assert ('error', 'Minimum lessons cannot exceed slots per day.') in flashes
+    assert _config_row(app.DB_PATH) == original
+
+
+def test_reject_max_lessons_greater_than_slots(tmp_path):
+    import app
+
+    conn = setup_db(tmp_path)
+    conn.close()
+    original = _config_row(app.DB_PATH)
+
+    data = _valid_config_form(original)
+    slots = original['slots_per_day']
+    data.setlist('max_lessons', [str(slots + 1)])
+
+    with app.app.test_request_context('/config', method='POST', data=data):
+        response = app.config()
+        flashes = get_flashed_messages(with_categories=True)
+
+    assert response.status_code == 302
+    assert ('error', 'Maximum lessons cannot exceed slots per day.') in flashes
+    assert _config_row(app.DB_PATH) == original
+
+
+def test_reject_teacher_min_lessons_greater_than_slots(tmp_path):
+    import app
+
+    conn = setup_db(tmp_path)
+    conn.close()
+    original = _config_row(app.DB_PATH)
+
+    data = _valid_config_form(original)
+    slots = original['slots_per_day']
+    data.setlist('teacher_min_lessons', [str(slots + 1)])
+    data.setlist('teacher_max_lessons', [str(slots + 2)])
+
+    with app.app.test_request_context('/config', method='POST', data=data):
+        response = app.config()
+        flashes = get_flashed_messages(with_categories=True)
+
+    assert response.status_code == 302
+    assert ('error', 'Global teacher minimum lessons cannot exceed slots per day.') in flashes
+    assert _config_row(app.DB_PATH) == original
+
+
+def test_reject_teacher_max_lessons_greater_than_slots(tmp_path):
+    import app
+
+    conn = setup_db(tmp_path)
+    conn.close()
+    original = _config_row(app.DB_PATH)
+
+    data = _valid_config_form(original)
+    slots = original['slots_per_day']
+    data.setlist('teacher_max_lessons', [str(slots + 1)])
+
+    with app.app.test_request_context('/config', method='POST', data=data):
+        response = app.config()
+        flashes = get_flashed_messages(with_categories=True)
+
+    assert response.status_code == 302
+    assert ('error', 'Global teacher maximum lessons cannot exceed slots per day.') in flashes
+    assert _config_row(app.DB_PATH) == original
+
+
+def test_reject_teacher_individual_min_exceeding_slots(tmp_path):
+    import app
+
+    conn = setup_db(tmp_path)
+    config_row = _config_row(app.DB_PATH)
+    slots = config_row['slots_per_day']
+
+    teacher = conn.execute(
+        'SELECT id, name, subjects, min_lessons, max_lessons FROM teachers ORDER BY id LIMIT 1'
+    ).fetchone()
+    conn.close()
+
+    data = _teacher_edit_form(config_row, teacher)
+    data.setlist(f'teacher_min_{teacher["id"]}', [str(slots + 1)])
+
+    with app.app.test_request_context('/config', method='POST', data=data):
+        response = app.config()
+        flashes = get_flashed_messages(with_categories=True)
+
+    assert response.status_code == 302
+    expected = 'Teacher minimum lessons cannot exceed slots per day for ' + teacher['name'] + '.'
+    assert ('error', expected) in flashes
+
+    conn = sqlite3.connect(app.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    updated = conn.execute(
+        'SELECT min_lessons, max_lessons FROM teachers WHERE id=?',
+        (teacher['id'],),
+    ).fetchone()
+    conn.close()
+
+    assert updated['min_lessons'] == teacher['min_lessons']
+    assert updated['max_lessons'] == teacher['max_lessons']
+
+
+def test_reject_teacher_individual_max_exceeding_slots(tmp_path):
+    import app
+
+    conn = setup_db(tmp_path)
+    config_row = _config_row(app.DB_PATH)
+    slots = config_row['slots_per_day']
+
+    teacher = conn.execute(
+        'SELECT id, name, subjects, min_lessons, max_lessons FROM teachers ORDER BY id LIMIT 1'
+    ).fetchone()
+    conn.close()
+
+    data = _teacher_edit_form(config_row, teacher)
+    data.setlist(f'teacher_max_{teacher["id"]}', [str(slots + 2)])
+
+    with app.app.test_request_context('/config', method='POST', data=data):
+        response = app.config()
+        flashes = get_flashed_messages(with_categories=True)
+
+    assert response.status_code == 302
+    expected = 'Teacher maximum lessons cannot exceed slots per day for ' + teacher['name'] + '.'
+    assert ('error', expected) in flashes
+
+    conn = sqlite3.connect(app.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    updated = conn.execute(
+        'SELECT min_lessons, max_lessons FROM teachers WHERE id=?',
+        (teacher['id'],),
+    ).fetchone()
+    conn.close()
+
+    assert updated['min_lessons'] == teacher['min_lessons']
+    assert updated['max_lessons'] == teacher['max_lessons']
+
+
+def test_reject_teacher_individual_min_greater_than_max(tmp_path):
+    import app
+
+    conn = setup_db(tmp_path)
+    config_row = _config_row(app.DB_PATH)
+    slots = config_row['slots_per_day']
+
+    teacher = conn.execute(
+        'SELECT id, name, subjects, min_lessons, max_lessons FROM teachers ORDER BY id LIMIT 1'
+    ).fetchone()
+    conn.close()
+
+    data = _teacher_edit_form(config_row, teacher)
+    data.setlist(f'teacher_min_{teacher["id"]}', [str(slots)])
+    data.setlist(f'teacher_max_{teacher["id"]}', [str(max(slots - 1, 0))])
+
+    with app.app.test_request_context('/config', method='POST', data=data):
+        response = app.config()
+        flashes = get_flashed_messages(with_categories=True)
+
+    assert response.status_code == 302
+    expected = 'Teacher min lessons greater than max for ' + teacher['name']
+    assert ('error', expected) in flashes
+
+    conn = sqlite3.connect(app.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    updated = conn.execute(
+        'SELECT min_lessons, max_lessons FROM teachers WHERE id=?',
+        (teacher['id'],),
+    ).fetchone()
+    conn.close()
+
+    assert updated['min_lessons'] == teacher['min_lessons']
+    assert updated['max_lessons'] == teacher['max_lessons']
+
+
+def test_reject_student_individual_min_exceeding_slots(tmp_path):
+    import app
+
+    conn = setup_db(tmp_path)
+    config_row = _config_row(app.DB_PATH)
+    slots = config_row['slots_per_day']
+
+    student = conn.execute(
+        'SELECT id, name, subjects, active, min_lessons, max_lessons FROM students ORDER BY id LIMIT 1'
+    ).fetchone()
+    conn.close()
+
+    data = _student_edit_form(config_row, student)
+    data.setlist(f'student_min_{student["id"]}', [str(slots + 3)])
+
+    with app.app.test_request_context('/config', method='POST', data=data):
+        response = app.config()
+        flashes = get_flashed_messages(with_categories=True)
+
+    assert response.status_code == 302
+    expected = 'Student minimum lessons cannot exceed slots per day for ' + student['name'] + '.'
+    assert ('error', expected) in flashes
+
+    conn = sqlite3.connect(app.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    updated = conn.execute(
+        'SELECT min_lessons, max_lessons FROM students WHERE id=?',
+        (student['id'],),
+    ).fetchone()
+    conn.close()
+
+    assert updated['min_lessons'] == student['min_lessons']
+    assert updated['max_lessons'] == student['max_lessons']
+
+
+def test_reject_student_individual_max_exceeding_slots(tmp_path):
+    import app
+
+    conn = setup_db(tmp_path)
+    config_row = _config_row(app.DB_PATH)
+    slots = config_row['slots_per_day']
+
+    student = conn.execute(
+        'SELECT id, name, subjects, active, min_lessons, max_lessons FROM students ORDER BY id LIMIT 1'
+    ).fetchone()
+    conn.close()
+
+    data = _student_edit_form(config_row, student)
+    data.setlist(f'student_max_{student["id"]}', [str(slots + 5)])
+
+    with app.app.test_request_context('/config', method='POST', data=data):
+        response = app.config()
+        flashes = get_flashed_messages(with_categories=True)
+
+    assert response.status_code == 302
+    expected = 'Student maximum lessons cannot exceed slots per day for ' + student['name'] + '.'
+    assert ('error', expected) in flashes
+
+    conn = sqlite3.connect(app.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    updated = conn.execute(
+        'SELECT min_lessons, max_lessons FROM students WHERE id=?',
+        (student['id'],),
+    ).fetchone()
+    conn.close()
+
+    assert updated['min_lessons'] == student['min_lessons']
+    assert updated['max_lessons'] == student['max_lessons']
+
+
+def test_reject_student_individual_min_greater_than_max(tmp_path):
+    import app
+
+    conn = setup_db(tmp_path)
+    config_row = _config_row(app.DB_PATH)
+    slots = config_row['slots_per_day']
+
+    student = conn.execute(
+        'SELECT id, name, subjects, active, min_lessons, max_lessons FROM students ORDER BY id LIMIT 1'
+    ).fetchone()
+    conn.close()
+
+    data = _student_edit_form(config_row, student)
+    data.setlist(f'student_min_{student["id"]}', [str(slots)])
+    data.setlist(f'student_max_{student["id"]}', [str(max(slots - 1, 0))])
+
+    with app.app.test_request_context('/config', method='POST', data=data):
+        response = app.config()
+        flashes = get_flashed_messages(with_categories=True)
+
+    assert response.status_code == 302
+    expected = 'Student min lessons greater than max for ' + student['name']
+    assert ('error', expected) in flashes
+
+    conn = sqlite3.connect(app.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    updated = conn.execute(
+        'SELECT min_lessons, max_lessons FROM students WHERE id=?',
+        (student['id'],),
+    ).fetchone()
+    conn.close()
+
+    assert updated['min_lessons'] == student['min_lessons']
+    assert updated['max_lessons'] == student['max_lessons']


### PR DESCRIPTION
## Summary
- add dedicated Save/Cancel controls to the configuration advanced modals and hook the Save action to the main form
- record modal field state on open so Cancel can restore the original values before closing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cea267f7608322bc5f2647c520534d