### PR TITLE
Require explicit shortcut for config form submissions

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -662,7 +662,10 @@
 </div>
         <div class="sticky-action-bar flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
             <a href="{{ url_for('index') }}" class="inline-flex w-full sm:w-auto justify-center bg-white text-emerald-700 border border-emerald-300 rounded-md px-3 py-2 hover:bg-emerald-100 transition">Cancel</a>
-            <button type="submit" class="w-full sm:w-auto bg-emerald-500 text-white border border-emerald-500 rounded-md px-3 py-2 hover:bg-emerald-600 transition">Save</button>
+            <div class="flex flex-col w-full sm:w-auto items-stretch sm:items-end gap-1">
+                <button type="submit" data-config-save title="Click Save or press Ctrl+Enter" class="w-full sm:w-auto bg-emerald-500 text-white border border-emerald-500 rounded-md px-3 py-2 hover:bg-emerald-600 transition">Save</button>
+                <p class="text-xs text-emerald-700 text-center sm:text-right">Shortcut: <kbd>Ctrl</kbd> + <kbd>Enter</kbd></p>
+            </div>
         </div>
     </form>
 


### PR DESCRIPTION
## Summary
- gate the configuration form submission behind an explicit allow list so plain Enter presses are ignored while Ctrl/⌘+Enter and the Save button still submit
- update modal helpers to use the shared submit trigger and add tooltip plus helper text advertising the new Ctrl+Enter shortcut near the Save button

## Testing
- pytest
- Manual smoke test of /config confirming plain Enter is ignored, Ctrl+Enter submits, and the Save button submits

------
https://chatgpt.com/codex/tasks/task_e_68ceab8d45c48322826a661a414c3d5f