### PR TITLE
Validate repeat settings when repeats disabled

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -177,23 +177,23 @@
             <label class="block">Max lessons per teacher:
                 <input type="number" name="teacher_max_lessons" value="{{ config['teacher_max_lessons'] }}" class="border border-emerald-300 rounded-lg p-2.5 w-full">
             </label>
-            <label class="flex items-center gap-2">Allow repeated lessons?
-                <input type="checkbox" name="allow_repeats" {% if config['allow_repeats'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+            <label class="flex items-center gap-2" for="allow_repeats">Allow repeated lessons?
+                <input id="allow_repeats" type="checkbox" name="allow_repeats" data-repeat-target="max_repeats allow_consecutive prefer_consecutive consecutive_weight" {% if config['allow_repeats'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
             </label>
             <label class="flex items-center gap-2">Allow different teachers per subject?
                 <input type="checkbox" name="allow_multi_teacher" {% if config['allow_multi_teacher'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
             </label>
-            <label class="block">Max repeats per teacher/subject:
-                <input type="number" name="max_repeats" value="{{ config['max_repeats'] }}" min="1" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+            <label class="block" for="max_repeats">Max repeats per teacher/subject:
+                <input id="max_repeats" type="number" name="max_repeats" value="{{ config['max_repeats'] }}" min="1" {% if not config['allow_repeats'] %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
             </label>
-            <label class="flex items-center gap-2">Allow consecutive repeat slots?
-                <input type="checkbox" name="allow_consecutive" {% if config['allow_consecutive'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+            <label class="flex items-center gap-2" for="allow_consecutive">Allow consecutive repeat slots?
+                <input id="allow_consecutive" type="checkbox" name="allow_consecutive" {% if config['allow_consecutive'] %}checked{% endif %} {% if not config['allow_repeats'] %}disabled{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
             </label>
-            <label class="flex items-center gap-2">Prefer consecutive repeats?
-                <input type="checkbox" name="prefer_consecutive" {% if config['prefer_consecutive'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
+            <label class="flex items-center gap-2" for="prefer_consecutive">Prefer consecutive repeats?
+                <input id="prefer_consecutive" type="checkbox" name="prefer_consecutive" {% if config['prefer_consecutive'] %}checked{% endif %} {% if not config['allow_repeats'] %}disabled{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
             </label>
-            <label class="block">Consecutive preference weight:
-                <input type="number" name="consecutive_weight" value="{{ config['consecutive_weight'] }}" min="1" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+            <label class="block" for="consecutive_weight">Consecutive preference weight:
+                <input id="consecutive_weight" type="number" name="consecutive_weight" value="{{ config['consecutive_weight'] }}" min="1" {% if not config['allow_repeats'] %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
             </label>
             <label class="flex items-center gap-2">Require all subjects?
                 <input type="checkbox" name="require_all_subjects" {% if config['require_all_subjects'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
@@ -690,16 +690,19 @@
     }
 
     function bindRepeatToggle(toggle) {
-        const targetId = toggle.dataset.repeatTarget;
-        if (!targetId) {
-            return;
-        }
-        const select = document.getElementById(targetId);
-        if (!select) {
+        const targetAttr = toggle.dataset.repeatTarget || '';
+        const targets = targetAttr
+            .split(/\s+/)
+            .map(id => id && document.getElementById(id))
+            .filter(Boolean);
+        if (!targets.length) {
             return;
         }
         const updateDisabledState = () => {
-            select.disabled = !toggle.checked;
+            const disabled = !toggle.checked;
+            targets.forEach(target => {
+                target.disabled = disabled;
+            });
         };
         toggle.addEventListener('change', updateDisabledState);
         updateDisabledState();

--- a/templates/config.html
+++ b/templates/config.html
@@ -23,6 +23,9 @@
         border-top-left-radius: 0;
         border-top-right-radius: 0;
     }
+    .repeat-control.repeat-disabled {
+        opacity: 0.6;
+    }
     </style>
 </head>
 <body class="bg-emerald-50 min-h-screen">
@@ -183,16 +186,16 @@
             <label class="flex items-center gap-2">Allow different teachers per subject?
                 <input type="checkbox" name="allow_multi_teacher" {% if config['allow_multi_teacher'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
             </label>
-            <label class="block" for="max_repeats">Max repeats per teacher/subject:
+            <label class="block repeat-control {% if not config['allow_repeats'] %}repeat-disabled{% endif %}" for="max_repeats">Max repeats per teacher/subject:
                 <input id="max_repeats" type="number" name="max_repeats" value="{{ config['max_repeats'] }}" min="1" {% if not config['allow_repeats'] %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
             </label>
-            <label class="flex items-center gap-2" for="allow_consecutive">Allow consecutive repeat slots?
+            <label class="flex items-center gap-2 repeat-control {% if not config['allow_repeats'] %}repeat-disabled{% endif %}" for="allow_consecutive">Allow consecutive repeat slots?
                 <input id="allow_consecutive" type="checkbox" name="allow_consecutive" {% if config['allow_consecutive'] %}checked{% endif %} {% if not config['allow_repeats'] %}disabled{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
             </label>
-            <label class="flex items-center gap-2" for="prefer_consecutive">Prefer consecutive repeats?
+            <label class="flex items-center gap-2 repeat-control {% if not config['allow_repeats'] %}repeat-disabled{% endif %}" for="prefer_consecutive">Prefer consecutive repeats?
                 <input id="prefer_consecutive" type="checkbox" name="prefer_consecutive" {% if config['prefer_consecutive'] %}checked{% endif %} {% if not config['allow_repeats'] %}disabled{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
             </label>
-            <label class="block" for="consecutive_weight">Consecutive preference weight:
+            <label class="block repeat-control {% if not config['allow_repeats'] %}repeat-disabled{% endif %}" for="consecutive_weight">Consecutive preference weight:
                 <input id="consecutive_weight" type="number" name="consecutive_weight" value="{{ config['consecutive_weight'] }}" min="1" {% if not config['allow_repeats'] %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
             </label>
             <label class="flex items-center gap-2">Require all subjects?
@@ -700,8 +703,17 @@
         }
         const updateDisabledState = () => {
             const disabled = !toggle.checked;
+            const wrappers = Array.from(new Set(
+                targets
+                    .map(target => target.closest('.repeat-control'))
+                    .filter(Boolean)
+            ));
             targets.forEach(target => {
                 target.disabled = disabled;
+                target.classList.toggle('cursor-not-allowed', disabled);
+            });
+            wrappers.forEach(wrapper => {
+                wrapper.classList.toggle('repeat-disabled', disabled);
             });
         };
         toggle.addEventListener('change', updateDisabledState);

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -255,9 +255,15 @@ def test_repeat_controls_render_disabled_when_repeats_off(tmp_path):
         def __init__(self):
             super().__init__()
             self.inputs = []
+            self.labels = {}
 
         def handle_starttag(self, tag, attrs):
             if tag != 'input':
+                if tag == 'label':
+                    attrs_dict = dict(attrs)
+                    target = attrs_dict.get('for')
+                    if target:
+                        self.labels[target] = attrs_dict
                 return
             self.inputs.append(dict(attrs))
 
@@ -273,6 +279,17 @@ def test_repeat_controls_render_disabled_when_repeats_off(tmp_path):
 
     for field in ('max_repeats', 'allow_consecutive', 'prefer_consecutive', 'consecutive_weight'):
         assert_disabled(field)
+
+    def assert_dimmed(field_id):
+        attrs = parser.labels.get(field_id)
+        assert attrs is not None, f'Label for {field_id} should be present'
+        classes = attrs.get('class', '')
+        class_list = classes.split()
+        assert 'repeat-control' in class_list, f'Label for {field_id} should mark repeat-control'
+        assert 'repeat-disabled' in class_list, f'Label for {field_id} should be dimmed when repeats are off'
+
+    for label_id in ('max_repeats', 'allow_consecutive', 'prefer_consecutive', 'consecutive_weight'):
+        assert_dimmed(label_id)
 
 
 def test_reject_min_lessons_greater_than_max(tmp_path):


### PR DESCRIPTION
## Summary
- block submissions that tweak repeat-only options when repeated lessons are disabled and restore stored values instead
- tie the repeat checkbox to all repeat-specific inputs in the template and generalize the helper script
- cover the new validation and template behaviour with integration and rendering regression tests

## Testing
- pytest tests/test_config_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68cf51374c2483229dffeb2e9597fde9