### PR TITLE
Use subject names in group teacher validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -1982,7 +1982,8 @@ def config():
                         ok = True
                         break
                 if not ok:
-                    flash(f'No teacher available for {subj} in group {name}', 'error')
+                    subject_label = subject_name_map.get(subj) or str(subj)
+                    flash(f'No teacher available for {subject_label} in group {name}', 'error')
                     has_error = True
                     valid = False
                     break
@@ -2019,7 +2020,8 @@ def config():
                         ok = True
                         break
                 if not ok:
-                    flash(f'No teacher available for {subj} in group {ng_name}', 'error')
+                    subject_label = subject_name_map.get(subj) or str(subj)
+                    flash(f'No teacher available for {subject_label} in group {ng_name}', 'error')
                     has_error = True
                     valid = False
                     break


### PR DESCRIPTION
## Summary
- update group validation error messages to resolve subject IDs through the subject name map
- add a regression test that blocks the last teacher for a subject and checks the flashed group error uses the friendly name

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d298013ea48322a78e286763658fde