### PR TITLE
Load flash messages from JSON payloads

### DIFF
--- a/static/config.js
+++ b/static/config.js
@@ -778,9 +778,7 @@ document.addEventListener('DOMContentLoaded', function () {
         const tids = Array.from(unavailTeacher.selectedOptions).map(o => o.value);
         const slots = Array.from(unavailSlot.selectedOptions).map(o => parseInt(o.value, 10) - 1);
         if (!tids.length || !slots.length) return;
-        const flashes = document.getElementById('flash-messages');
-        if (!flashes) return;
-        let added = 0;
+        const messages = [];
         tids.forEach(tid => {
             const fixed = assignData[tid] || [];
             const unav = unavailData[tid] || [];
@@ -792,16 +790,15 @@ document.addEventListener('DOMContentLoaded', function () {
                     msg = 'Slot already marked unavailable.';
                 }
                 if (msg) {
-                    const li = document.createElement('li');
-                    li.className = 'error';
-                    li.textContent = msg;
-                    flashes.appendChild(li);
-                    added += 1;
+                    messages.push({
+                        category: 'error',
+                        text: msg
+                    });
                 }
             });
         });
-        if (added && typeof window.renderFlashToasts === 'function') {
-            window.renderFlashToasts();
+        if (messages.length && typeof window.enqueueFlashMessages === 'function') {
+            window.enqueueFlashMessages(messages, { category: 'error' });
         }
     }
     if (unavailTeacher && unavailSlot) {

--- a/static/style.css
+++ b/static/style.css
@@ -14,18 +14,6 @@ td, th {
 }
 /* Simple styling for error messages */
 
-.flashes {
-    list-style: none;
-    padding: 0;
-    margin: 1em 0;
-    color: red;
-}
-
-.flashes[data-flash-enhanced="true"],
-[data-flash-messages][data-flash-enhanced="true"] {
-    display: none !important;
-}
-
 /* Highlight subjects with worksheets on the selected date */
 .worksheet-assigned {
     background-color: #A7F3D0; /* emerald-200 */

--- a/templates/config.html
+++ b/templates/config.html
@@ -47,13 +47,9 @@
     </ul>
     {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
-    <ul id="flash-messages" class="flashes mb-4 text-center" data-flash-messages>
-        {% for category, msg in messages %}
-        <li class="{{ category }}">{{ msg }}</li>
-        {% endfor %}
-    </ul>
+    <script type="application/json" data-flash-payload>{{ messages|tojson }}</script>
     {% endif %}
-{% endwith %}
+    {% endwith %}
     <div class="mb-6">
         <h2 class="text-xl text-emerald-900 font-semibold mb-2">Presets</h2>
         <form method="post" action="{{ url_for('save_preset') }}" class="flex gap-2 mb-2">

--- a/templates/edit_timetable.html
+++ b/templates/edit_timetable.html
@@ -11,11 +11,7 @@
         <h1 class="text-2xl text-emerald-900 font-semibold mb-4 text-center">Edit Timetable for {{ date }}</h1>
         {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
-        <ul class="flashes mb-4 text-center" data-flash-messages>
-            {% for category, msg in messages %}
-            <li class="{{ category }}">{{ msg }}</li>
-            {% endfor %}
-        </ul>
+        <script type="application/json" data-flash-payload>{{ messages|tojson }}</script>
         {% endif %}
         {% endwith %}
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,11 +12,7 @@
         <h1 class="text-2xl text-emerald-900 font-semibold mb-4 text-center">Welcome to the Timetabling App</h1>
         {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
-        <ul class="flashes mb-4 text-center" data-flash-messages>
-            {% for category, msg in messages %}
-            <li class="{{ category }}">{{ msg }}</li>
-            {% endfor %}
-        </ul>
+        <script type="application/json" data-flash-payload>{{ messages|tojson }}</script>
         {% endif %}
         {% endwith %}
         <ul class="flex justify-center text-lg text-center text-emerald-700 border-b border-emerald-200 dark:text-emerald-300 dark:border-emerald-700 mb-6" role="tablist">

--- a/templates/manage_timetables.html
+++ b/templates/manage_timetables.html
@@ -12,11 +12,7 @@
         <h1 class="text-2xl text-emerald-900 font-semibold mb-4 text-center">Manage Saved Timetables</h1>
         {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
-        <ul class="flashes mb-4 text-center" data-flash-messages>
-            {% for category, msg in messages %}
-            <li class="{{ category }}">{{ msg }}</li>
-            {% endfor %}
-        </ul>
+        <script type="application/json" data-flash-payload>{{ messages|tojson }}</script>
         {% endif %}
         {% endwith %}
         <ul class="flex justify-center text-lg text-center text-emerald-700 border-b border-emerald-200 dark:text-emerald-300 dark:border-emerald-700 mb-6" role="tablist">

--- a/templates/timetable.html
+++ b/templates/timetable.html
@@ -10,11 +10,7 @@
     <h1>Timetable for {{ date }}</h1>
     {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
-    <ul class="flashes" data-flash-messages>
-        {% for category, msg in messages %}
-        <li class="{{ category }}">{{ msg }}</li>
-        {% endfor %}
-    </ul>
+    <script type="application/json" data-flash-payload>{{ messages|tojson }}</script>
     {% endif %}
     {% endwith %}
     <table border="1" cellpadding="5">


### PR DESCRIPTION
## Summary
- embed flash message data in JSON script tags across templates so nothing renders before the toast UI
- update the toast renderer to parse the JSON payloads and normalise message formats
- remove the unused CSS that hid the legacy flash lists

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8774620488322a6892637e1e056cd