### PR TITLE
Normalize repeat max inputs when toggling repeats

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -235,7 +235,7 @@
                 <input type="checkbox" name="allow_multi_teacher" {% if config['allow_multi_teacher'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
             </label>
             <label class="block repeat-control {% if not config['allow_repeats'] %}repeat-disabled{% endif %}" for="max_repeats">Max repeats per teacher/subject:
-                <input id="max_repeats" type="number" name="max_repeats" value="{{ config['max_repeats'] }}" min="2" {% if not config['allow_repeats'] %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                <input id="max_repeats" type="number" name="max_repeats" value="{{ config['max_repeats'] }}" min="2" data-repeat-off-value="1" {% if not config['allow_repeats'] %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
             </label>
             <label class="flex items-center gap-2 repeat-control {% if not config['allow_repeats'] %}repeat-disabled{% endif %}" for="allow_consecutive">Allow consecutive repeat slots?
                 <input id="allow_consecutive" type="checkbox" name="allow_consecutive" {% if config['allow_consecutive'] %}checked{% endif %} {% if not config['allow_repeats'] %}disabled{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
@@ -518,7 +518,7 @@
                             </label>
                             <div class="repeat-control {% if not student_allow_repeats %}repeat-disabled{% endif %}">
                                 <label class="block" for="student_max_repeats_{{ s['id'] }}">Max repeats:
-                                    <input id="student_max_repeats_{{ s['id'] }}" type="number" name="student_max_repeats_{{ s['id'] }}" value="{{ s['max_repeats'] if s['max_repeats'] is not none else config['max_repeats'] }}" min="2" {% if not student_allow_repeats %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                                    <input id="student_max_repeats_{{ s['id'] }}" type="number" name="student_max_repeats_{{ s['id'] }}" value="{{ s['max_repeats'] if s['max_repeats'] is not none else config['max_repeats'] }}" min="2" data-repeat-off-value="1" {% if not student_allow_repeats %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
                                 </label>
                             </div>
                             <div class="repeat-control {% if not student_allow_repeats %}repeat-disabled{% endif %}">
@@ -602,7 +602,7 @@
                             </label>
                             <div class="repeat-control {% if not new_student_allow_repeats %}repeat-disabled{% endif %}">
                                 <label class="block" for="new_student_max_repeats">Max repeats:
-                                    <input id="new_student_max_repeats" type="number" name="new_student_max_repeats" value="{{ config['max_repeats'] }}" min="2" {% if not new_student_allow_repeats %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                                    <input id="new_student_max_repeats" type="number" name="new_student_max_repeats" value="{{ config['max_repeats'] }}" min="2" data-repeat-off-value="1" {% if not new_student_allow_repeats %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
                                 </label>
                             </div>
                             <div class="repeat-control {% if not new_student_allow_repeats %}repeat-disabled{% endif %}">
@@ -839,6 +839,19 @@
         if (!targets.length) {
             return;
         }
+
+        const numericTargets = targets.filter(target => target.type === 'number');
+
+        const setNumberValue = (target, value) => {
+            if (value === undefined) {
+                return;
+            }
+            const numericValue = Number(value);
+            if (!Number.isNaN(numericValue)) {
+                target.value = numericValue;
+            }
+        };
+
         const updateDisabledState = () => {
             const disabled = !toggle.checked;
             const wrappers = Array.from(new Set(
@@ -846,14 +859,33 @@
                     .map(target => target.closest('.repeat-control'))
                     .filter(Boolean)
             ));
+
             targets.forEach(target => {
                 target.disabled = disabled;
                 target.classList.toggle('cursor-not-allowed', disabled);
             });
+
+            if (disabled) {
+                numericTargets.forEach(target => {
+                    const offValue = target.dataset.repeatOffValue;
+                    setNumberValue(target, offValue);
+                });
+            } else {
+                numericTargets.forEach(target => {
+                    const minAttr = target.dataset.repeatOnMin || target.min;
+                    const minValue = Number(minAttr);
+                    const currentValue = Number(target.value);
+                    if (!Number.isNaN(minValue) && (Number.isNaN(currentValue) || currentValue < minValue)) {
+                        setNumberValue(target, minValue);
+                    }
+                });
+            }
+
             wrappers.forEach(wrapper => {
                 wrapper.classList.toggle('repeat-disabled', disabled);
             });
         };
+
         toggle.addEventListener('change', updateDisabledState);
         updateDisabledState();
     }

--- a/templates/config.html
+++ b/templates/config.html
@@ -244,7 +244,7 @@
                 <input id="prefer_consecutive" type="checkbox" name="prefer_consecutive" {% if config['prefer_consecutive'] %}checked{% endif %} {% if not config['allow_repeats'] %}disabled{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
             </label>
             <label class="block repeat-control {% if not config['allow_repeats'] %}repeat-disabled{% endif %}" for="consecutive_weight">Consecutive preference weight:
-                <input id="consecutive_weight" type="number" name="consecutive_weight" value="{{ config['consecutive_weight'] }}" min="1" {% if not config['allow_repeats'] %}disabled{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                <input id="consecutive_weight" type="number" name="consecutive_weight" value="{{ config['consecutive_weight'] }}" min="1" data-repeat-disable-mode="readonly" {% if not config['allow_repeats'] %}readonly aria-disabled="true"{% endif %} class="border border-emerald-300 rounded-lg p-2.5 w-full">
             </label>
             <label class="flex items-center gap-2">Require all subjects?
                 <input type="checkbox" name="require_all_subjects" {% if config['require_all_subjects'] %}checked{% endif %} class="w-4 h-4 text-emerald-600 bg-emerald-100 border-emerald-300 rounded focus:ring-emerald-500">
@@ -861,7 +861,21 @@
             ));
 
             targets.forEach(target => {
-                target.disabled = disabled;
+                const disableMode = target.dataset.repeatDisableMode || 'disabled';
+                if (disableMode === 'readonly') {
+                    target.disabled = false;
+                    target.readOnly = disabled;
+                } else {
+                    target.disabled = disabled;
+                    if (!disabled && target.readOnly) {
+                        target.readOnly = false;
+                    }
+                }
+                if (disabled) {
+                    target.setAttribute('aria-disabled', 'true');
+                } else {
+                    target.removeAttribute('aria-disabled');
+                }
                 target.classList.toggle('cursor-not-allowed', disabled);
             });
 


### PR DESCRIPTION
## Summary
- ensure max repeat inputs keep a 1 fallback while repeats are disabled by tagging them with data attributes
- update the repeat toggle helper to enforce numeric minimums when re-enabled and restore fallback values when disabled

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d886a3fbe0832289f530d154d6e2ea