### PR TITLE
Refresh help copy for batch student tools

### DIFF
--- a/CODE_GUIDE.txt
+++ b/CODE_GUIDE.txt
@@ -85,7 +85,7 @@ Backend fundamentals
 
 ### Route overview (located in `app.py`)
 - **Landing and generation** – `index`, `check_timetable`, `timetable`, and `generate` handle viewing and triggering schedules.
-- **Configuration** – `config` renders the configuration form, performs extensive validation and commits changes to the database.
+- **Configuration** – `config` renders the configuration form, performs extensive validation and commits changes to the database. It also powers batch student updates, advanced override dialogs and preset management utilities.
 - **Presets** – `/presets` plus POST endpoints for saving, loading and deleting presets.
 - **Attendance & management** – `attendance`, `manage_timetables`, `delete_timetables` and related helpers surface past schedules, attendance summaries and backups.
 - **Editing** – `edit_timetable` lets you fine-tune lessons, toggle worksheets and keep attendance in sync.
@@ -95,7 +95,7 @@ Front-end overview
 ------------------
 - Templates live in `templates/`. Each template expects specific context variables defined in its matching route. If you rename context keys, update every template that uses them.
 - JavaScript lives in `static/`:
-  - `config.js` dynamically updates the configuration form (dropdowns, warnings, time inputs).
+  - `config.js` dynamically updates the configuration form (dropdowns, warnings, time inputs), drives batch student actions, keeps advanced modal state in sync and restores accordion visibility from local storage.
   - `main.js` handles confirmation prompts and AJAX helpers for timetable edits.
   - `attendance.js` enhances attendance tables with sorting and search.
   - `ui.js` initialises Flowbite components across pages.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The application focuses on a local, privacy-friendly workflow. All data lives in
 
 - Configure teachers, students, subjects, groups and locations from a single configuration page, including availability, fixed lessons and per-student restrictions.
 - Capture nuanced student rules such as teacher blocks, repeat limits, slot unavailability and permitted locations.
+- Apply batch student actions to update blocked slots, subject membership, teacher blocks and allowed locations across many students while preserving their existing settings.
 - Generate timetables with OR-Tools CP-SAT, balancing teacher workloads, honoring attendance priorities, respecting location limits and applying a configurable solver time limit.
 - Switch between teacher and location views, highlight unmet subject requirements, and inspect lesson counts and group membership snapshots for each schedule.
 - Edit saved timetables, assign worksheets, or remove lessons while attendance logs stay in sync.
@@ -143,9 +144,10 @@ Visit `/config` after launching the server to manage all scheduling inputs. The 
 
 ### Students and groups
 
-- Maintain active students, their required subjects, lesson limits and repeat preferences (including per-subject repeat allow-lists).
+- Maintain active students, their required subjects, lesson limits and repeat preferences (including per-subject repeat allow-lists). Use the _Needs lessons?_ toggle to temporarily exclude a student from scheduling without deleting their data.
 - Record student unavailability, block individual teachers (while ensuring viable alternatives remain) and restrict allowable locations.
 - Group students for joint lessons. Each subject in the group must be taught by at least one unblocked teacher, and optional location limits can keep lessons in suitable rooms.
+- Use the batch student actions panel to add or remove blocked slots, subjects, teacher blocks and allowed locations for multiple students at once.
 
 ### Locations
 

--- a/templates/config.html
+++ b/templates/config.html
@@ -168,12 +168,15 @@
             <h3 class="text-base font-semibold text-emerald-900">Fixed Assignments</h3>
             <ul class="list-disc ms-6 mb-6 space-y-1">
                 <li>Use to force specific teacher, student (or group), subject, and slot combinations.</li>
+                <li>Optionally attach a location to reserve a room or resource for that lesson; the solver treats it as a hard requirement.</li>
                 <li>If both a student and a group are selected, the entry is saved for the group only when <em>group_weight &gt; 0</em> (or no student is chosen).</li>
             </ul>
 
-            <h3 class="text-base font-semibold text-emerald-900">Per-student Overrides</h3>
+            <h3 class="text-base font-semibold text-emerald-900">Batch tools &amp; per-student overrides</h3>
             <ul class="list-disc ms-6 mb-6 space-y-1">
-                <li>Adjust Min/Max lessons, Allow Repeats, Max Repeats, Allow/Prefer Consecutive, Allow Different Teachers per Subject, and Blocked Slots.</li>
+                <li>Use the <em>Batch student actions</em> panel to add or remove blocked slots, subjects, teacher blocks, and allowed locations for several students at once. Batch updates merge with existing values rather than replacing them outright.</li>
+                <li>The <em>Needs lessons?</em> toggle lets you temporarily archive a student without deleting their configuration—turn it off to keep historical data while skipping the student during scheduling.</li>
+                <li>Advanced dialogs provide per-student overrides for Min/Max lessons, repeat allowances, repeatable subjects, consecutive preferences, teacher-per-subject limits, and blocked slots.</li>
                 <li>Overrides apply only to the selected student and take priority over global defaults.</li>
             </ul>
 


### PR DESCRIPTION
## Summary
- expand the Help & Guidance accordion with notes about batch student actions, the Needs lessons toggle, and location-locked fixed assignments
- highlight batch student tooling in the README key features and configuration workflow sections
- document batch-enabled configuration behaviour and config.js responsibilities in CODE_GUIDE.txt

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d904b481148322bec89e8d4bbb34f9