### PR TITLE
Add batch teacher actions and coverage

### DIFF
--- a/static/config.js
+++ b/static/config.js
@@ -445,7 +445,11 @@ document.addEventListener('DOMContentLoaded', function () {
         const batchLocationAction = configForm.querySelector('select[name="batch_location_action"]');
         const batchLocations = configForm.querySelector('select[name="batch_locations"]');
         const batchActiveAction = configForm.querySelector('select[name="batch_active_action"]');
-        const dependentSelects = [
+        const batchTeachers = configForm.querySelector('select[name="batch_teachers"]');
+        const batchTeacherSubjectAction = configForm.querySelector('select[name="batch_teacher_subject_action"]');
+        const batchTeacherSubjects = configForm.querySelector('select[name="batch_teacher_subjects"]');
+        const batchTeacherNeedAction = configForm.querySelector('select[name="batch_teacher_need_action"]');
+        const studentDependentSelects = [
             batchBlockAction,
             batchBlockSlots,
             batchSubjectAction,
@@ -456,7 +460,12 @@ document.addEventListener('DOMContentLoaded', function () {
             batchLocations,
             batchActiveAction
         ].filter(Boolean);
-        const validationSelects = [
+        const teacherDependentControls = [
+            batchTeacherSubjectAction,
+            batchTeacherSubjects,
+            batchTeacherNeedAction
+        ].filter(Boolean);
+        const studentValidationSelects = [
             batchBlockSlots,
             batchSubjects,
             batchTeacherTargets,
@@ -464,18 +473,26 @@ document.addEventListener('DOMContentLoaded', function () {
             batchActiveAction
         ].filter(Boolean);
         const defaultSelectValues = new Map();
-        dependentSelects.forEach(select => {
+        [...studentDependentSelects, ...teacherDependentControls].forEach(select => {
             if (!select.multiple) {
                 defaultSelectValues.set(select, select.value);
             }
         });
 
-        const batchLegend = document.getElementById('batch-student-actions-heading');
-        let batchSummaryBadge = null;
-        if (batchLegend) {
-            batchSummaryBadge = document.createElement('span');
-            batchSummaryBadge.className = 'ml-2 inline-flex items-center rounded-full bg-emerald-200 px-2 py-0.5 text-xs font-medium text-emerald-900';
-            batchLegend.appendChild(batchSummaryBadge);
+        const studentBatchLegend = document.getElementById('batch-student-actions-heading');
+        let studentBatchSummaryBadge = null;
+        if (studentBatchLegend) {
+            studentBatchSummaryBadge = document.createElement('span');
+            studentBatchSummaryBadge.className = 'ml-2 inline-flex items-center rounded-full bg-emerald-200 px-2 py-0.5 text-xs font-medium text-emerald-900';
+            studentBatchLegend.appendChild(studentBatchSummaryBadge);
+        }
+
+        const teacherBatchLegend = document.getElementById('batch-teacher-actions-heading');
+        let teacherBatchSummaryBadge = null;
+        if (teacherBatchLegend) {
+            teacherBatchSummaryBadge = document.createElement('span');
+            teacherBatchSummaryBadge.className = 'ml-2 inline-flex items-center rounded-full bg-emerald-200 px-2 py-0.5 text-xs font-medium text-emerald-900';
+            teacherBatchLegend.appendChild(teacherBatchSummaryBadge);
         }
 
         const getSelectedValues = element => {
@@ -504,28 +521,41 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         };
 
-        const updateBatchSummary = count => {
-            if (!batchSummaryBadge) {
+        const updateStudentBatchSummary = count => {
+            if (!studentBatchSummaryBadge) {
                 return;
             }
             if (count === 0) {
-                batchSummaryBadge.textContent = 'No students selected';
+                studentBatchSummaryBadge.textContent = 'No students selected';
             } else if (count === 1) {
-                batchSummaryBadge.textContent = '1 student selected';
+                studentBatchSummaryBadge.textContent = '1 student selected';
             } else {
-                batchSummaryBadge.textContent = `${count} students selected`;
+                studentBatchSummaryBadge.textContent = `${count} students selected`;
             }
         };
 
-        const refreshBatchControls = () => {
+        const updateTeacherBatchSummary = count => {
+            if (!teacherBatchSummaryBadge) {
+                return;
+            }
+            if (count === 0) {
+                teacherBatchSummaryBadge.textContent = 'No teachers selected';
+            } else if (count === 1) {
+                teacherBatchSummaryBadge.textContent = '1 teacher selected';
+            } else {
+                teacherBatchSummaryBadge.textContent = `${count} teachers selected`;
+            }
+        };
+
+        const refreshStudentBatchControls = () => {
             if (!batchStudents) {
                 return;
             }
             const selectedCount = getSelectedValues(batchStudents).length;
             const hasStudents = selectedCount > 0;
-            updateBatchSummary(selectedCount);
+            updateStudentBatchSummary(selectedCount);
 
-            dependentSelects.forEach(select => {
+            studentDependentSelects.forEach(select => {
                 select.disabled = !hasStudents;
                 if (!hasStudents) {
                     clearSelections(select);
@@ -533,23 +563,45 @@ document.addEventListener('DOMContentLoaded', function () {
             });
         };
 
+        const refreshTeacherBatchControls = () => {
+            if (!batchTeachers) {
+                return;
+            }
+            const selectedCount = getSelectedValues(batchTeachers).length;
+            const hasTeachers = selectedCount > 0;
+            updateTeacherBatchSummary(selectedCount);
+
+            teacherDependentControls.forEach(select => {
+                select.disabled = !hasTeachers;
+                if (!hasTeachers) {
+                    clearSelections(select);
+                }
+            });
+        };
+
         if (batchStudents) {
-            batchStudents.addEventListener('change', refreshBatchControls);
-            batchStudents.addEventListener('input', refreshBatchControls);
-            refreshBatchControls();
+            batchStudents.addEventListener('change', refreshStudentBatchControls);
+            batchStudents.addEventListener('input', refreshStudentBatchControls);
+            refreshStudentBatchControls();
 
             validateBatchActions = () => {
                 const hasStudents = getSelectedValues(batchStudents).length > 0;
                 if (hasStudents) {
                     return true;
                 }
-                const hasDependentSelections = validationSelects.some(select => getSelectedValues(select).length > 0);
+                const hasDependentSelections = studentValidationSelects.some(select => getSelectedValues(select).length > 0);
                 if (hasDependentSelections) {
                     alert('Select at least one student before applying batch changes.');
                     return false;
                 }
                 return true;
             };
+        }
+
+        if (batchTeachers) {
+            batchTeachers.addEventListener('change', refreshTeacherBatchControls);
+            batchTeachers.addEventListener('input', refreshTeacherBatchControls);
+            refreshTeacherBatchControls();
         }
     }
 

--- a/templates/config.html
+++ b/templates/config.html
@@ -318,6 +318,48 @@
         </button>
     </h2>
     <div id="body-teachers" class="hidden p-4 border border-b-0 border-emerald-200">
+        <fieldset class="space-y-4 mb-8 border border-emerald-200 rounded-lg p-4 bg-emerald-50/50" aria-labelledby="batch-teacher-actions-heading">
+            <legend id="batch-teacher-actions-heading" class="font-semibold text-emerald-900">Batch teacher actions</legend>
+            <p class="text-sm text-emerald-700">Select teachers to apply shared subject changes or toggle the <em>Need lessons?</em> flag for several teachers at once.</p>
+            <label class="block">
+                <span class="font-medium">Teachers</span>
+                <select multiple name="batch_teachers" class="border border-emerald-300 rounded-lg p-2.5 w-full" size="6">
+                    {% for t in teachers %}
+                    <option value="{{ t['id'] }}">{{ t['name'] }}</option>
+                    {% endfor %}
+                </select>
+            </label>
+            <div class="grid gap-4 md:grid-cols-2">
+                <fieldset class="space-y-2">
+                    <legend class="font-medium">Subjects</legend>
+                    <p class="text-sm text-emerald-700">Add or remove subjects from every selected teacher.</p>
+                    <label class="block">
+                        <span class="sr-only">Subject action</span>
+                        <select name="batch_teacher_subject_action" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                            <option value="add">Add selected subjects</option>
+                            <option value="remove">Remove selected subjects</option>
+                        </select>
+                    </label>
+                    <select multiple name="batch_teacher_subjects" class="border border-emerald-300 rounded-lg p-2.5 w-full" size="6">
+                        {% for sub in subjects %}
+                        <option value="{{ sub['id'] }}">{{ sub['name'] }}</option>
+                        {% endfor %}
+                    </select>
+                </fieldset>
+                <fieldset class="space-y-2">
+                    <legend class="font-medium">Need lessons?</legend>
+                    <p class="text-sm text-emerald-700">Toggle whether selected teachers should be considered when scheduling.</p>
+                    <label class="block">
+                        <span class="sr-only">Needs lessons action</span>
+                        <select name="batch_teacher_need_action" class="border border-emerald-300 rounded-lg p-2.5 w-full">
+                            <option value="no-change">No change</option>
+                            <option value="activate">Mark as needing lessons</option>
+                            <option value="deactivate">Mark as not needing lessons</option>
+                        </select>
+                    </label>
+                </fieldset>
+            </div>
+        </fieldset>
         <fieldset class="space-y-4">
             {% for t in teachers %}
             <input type="hidden" name="teacher_id" value="{{ t['id'] }}">


### PR DESCRIPTION
## Summary
- add a batch teacher action panel to the configuration template
- extend the configuration JavaScript to manage teacher batch widgets and summaries
- teach the /config handler to process teacher batch subject and need-lessons updates and cover the flows with regression tests

## Testing
- pytest
- pytest tests/test_config_validation.py::test_batch_teacher_subject_add tests/test_config_validation.py::test_batch_teacher_subject_remove tests/test_config_validation.py::test_batch_teacher_need_toggle

------
https://chatgpt.com/codex/tasks/task_e_68da780714888322add7601a6ecd7d33