### PR TITLE
Fix py launcher command quoting in run_app.bat

### DIFF
--- a/run_app.bat
+++ b/run_app.bat
@@ -62,7 +62,7 @@ if errorlevel 1 (
 
 REM Use the venv's interpreter for subsequent python invocations
 set "PYCMD=%VENV_PATH%\Scripts\python.exe"
-set "PYCMD_QUOTED=\"%PYCMD%\""
+set "PYCMD_QUOTED="%PYCMD%""
 
   REM Install/upgrade dependencies
   echo Installing dependencies from requirements.txt ...

--- a/run_app.bat
+++ b/run_app.bat
@@ -62,15 +62,16 @@ if errorlevel 1 (
 
 REM Use the venv's interpreter for subsequent python invocations
 set "PYCMD=%VENV_PATH%\Scripts\python.exe"
+set "PYCMD_QUOTED=\"%PYCMD%\""
 
   REM Install/upgrade dependencies
   echo Installing dependencies from requirements.txt ...
-  %PYCMD% -m pip install --upgrade pip >nul 2>&1
-  %PYCMD% -m pip install -r requirements.txt
+  %PYCMD_QUOTED% -m pip install --upgrade pip >nul 2>&1
+  %PYCMD_QUOTED% -m pip install -r requirements.txt
 if errorlevel 1 (
   echo.
   echo [ERROR] Dependency installation failed.
-  echo You can try running: %PYCMD% -m pip install -r requirements.txt
+  echo You can try running: %PYCMD_QUOTED% -m pip install -r requirements.txt
   pause
   exit /b 1
 )
@@ -78,7 +79,7 @@ if errorlevel 1 (
   REM Initialize DB and start the Flask app
   echo Launching the app...
   echo Open your browser to http://127.0.0.1:5000/
-  %PYCMD% app.py
+  %PYCMD_QUOTED% app.py
 
 echo.
 echo App exited. Press any key to close.

--- a/run_app.bat
+++ b/run_app.bat
@@ -62,24 +62,24 @@ if errorlevel 1 (
 
 REM Use the venv's interpreter for subsequent python invocations
 set "PYCMD=%VENV_PATH%\Scripts\python.exe"
-set "PYCMD_QUOTED="%PYCMD%""
+set "PYCMD_VENV=%PYCMD%"
 
-  REM Install/upgrade dependencies
-  echo Installing dependencies from requirements.txt ...
-  %PYCMD_QUOTED% -m pip install --upgrade pip >nul 2>&1
-  %PYCMD_QUOTED% -m pip install -r requirements.txt
+REM Install/upgrade dependencies
+echo Installing dependencies from requirements.txt ...
+"%PYCMD_VENV%" -m pip install --upgrade pip >nul 2>&1
+"%PYCMD_VENV%" -m pip install -r requirements.txt
 if errorlevel 1 (
   echo.
   echo [ERROR] Dependency installation failed.
-  echo You can try running: %PYCMD_QUOTED% -m pip install -r requirements.txt
+  echo You can try running: "%PYCMD_VENV%" -m pip install -r requirements.txt
   pause
   exit /b 1
 )
 
-  REM Initialize DB and start the Flask app
-  echo Launching the app...
-  echo Open your browser to http://127.0.0.1:5000/
-  %PYCMD_QUOTED% app.py
+REM Initialize DB and start the Flask app
+echo Launching the app...
+echo Open your browser to http://127.0.0.1:5000/
+"%PYCMD_VENV%" app.py
 
 echo.
 echo App exited. Press any key to close.
@@ -118,34 +118,6 @@ if !PYTMP_MINOR_NUM! GTR 13 exit /b 1
 set "PYCMD=%CAND%"
 set "PYDISPLAY=!PYTMP_OUT!"
 exit /b 0
-
-echo Installing dependencies from requirements.txt ...
-%PYCMD% -m pip install --upgrade pip >nul 2>&1
-%PYCMD% -m pip install -r requirements.txt
-if errorlevel 1 (
-  echo.
-  echo [ERROR] Dependency installation failed.
-  echo You can try running: %PYCMD% -m pip install -r requirements.txt
-  pause
-  exit /b 1
-)
-
-REM Initialize DB and start the Flask app
-echo Launching the app...
-echo Open your browser to http://127.0.0.1:5000/
-%PYCMD% app.py
-
-echo.
-echo App exited. Press any key to close.
-pause
-
-goto :eof
-
-:try_python
-set "CAND=%~1"
-set "PYTMP_OUT="
-for /f "tokens=1,2" %%a in ('cmd /c %CAND% --version 2^>nul') do (
-  if /i "%%a"=="Python" (
     set "PYTMP_OUT=%%b"
   )
 )

--- a/run_app.bat
+++ b/run_app.bat
@@ -65,8 +65,8 @@ set "PYCMD=%VENV_PATH%\Scripts\python.exe"
 
   REM Install/upgrade dependencies
   echo Installing dependencies from requirements.txt ...
-  "%PYCMD%" -m pip install --upgrade pip >nul 2>&1
-  "%PYCMD%" -m pip install -r requirements.txt
+  %PYCMD% -m pip install --upgrade pip >nul 2>&1
+  %PYCMD% -m pip install -r requirements.txt
 if errorlevel 1 (
   echo.
   echo [ERROR] Dependency installation failed.
@@ -78,7 +78,7 @@ if errorlevel 1 (
   REM Initialize DB and start the Flask app
   echo Launching the app...
   echo Open your browser to http://127.0.0.1:5000/
-  "%PYCMD%" app.py
+  %PYCMD% app.py
 
 echo.
 echo App exited. Press any key to close.


### PR DESCRIPTION
## Summary
- avoid wrapping py launcher commands in quotes so version flags are parsed correctly
- keep dependency installation and app launch working when only the py launcher satisfies the version check

## Testing
- not run (not applicable on this platform)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692272de76208322b06a871d0afabb83)